### PR TITLE
Add CODEOWNERS and contribution templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default ownership
+* @arailex
+
+# Release and platform-critical paths
+/.github/ @arailex
+/infra/ @arailex
+/scripts/ @arailex

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a reproducible problem in Sentinel or araiOS integration.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please include enough detail for us to reproduce and fix quickly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the issue and the expected behavior.
+      placeholder: "Expected X, but saw Y."
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Clear, minimal reproduction steps.
+      placeholder: |
+        1. Start stack with ...
+        2. Open ...
+        3. Click ...
+        4. Observe ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Git commit SHA, release tag, or branch.
+      placeholder: main@<sha>
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      options:
+        - Gateway
+        - Sentinel frontend
+        - Sentinel backend
+        - araiOS frontend
+        - araiOS backend
+        - Docker / Infra
+        - CLI
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Paste logs, stack traces, or screenshots.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/arais-labs/sentinel/security/advisories/new
+    about: Report security vulnerabilities privately.
+  - name: ARAIS
+    url: https://arais.us
+    about: Project overview and updates.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Propose an improvement to Sentinel or araiOS integration.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user problem are you trying to solve?
+      placeholder: "Today users struggle with ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe your suggested implementation.
+      placeholder: "Add ... so users can ..."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other options you evaluated.
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Expected impact
+      options:
+        - Small UX improvement
+        - Medium workflow improvement
+        - Major capability addition
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+Describe what changed and why.
+
+## Scope
+
+- [ ] Sentinel frontend
+- [ ] Sentinel backend
+- [ ] araiOS frontend
+- [ ] araiOS backend
+- [ ] Gateway
+- [ ] Infra / Docker / CI
+- [ ] Docs
+
+## Validation
+
+- [ ] Local tests pass
+- [ ] Manual flow tested
+- [ ] Screenshots attached (if UI change)
+
+## Risk
+
+List potential regressions and mitigation.
+
+## Checklist
+
+- [ ] No secrets were added
+- [ ] Documentation updated if behavior changed
+- [ ] Breaking changes are explicitly called out


### PR DESCRIPTION
## Summary
Add baseline repo hygiene for public collaboration.

## Changes
- Add `.github/CODEOWNERS`
- Add issue templates (`bug_report`, `feature_request`) and template config
- Add `.github/pull_request_template.md`

## Notes
- Keeps existing branch protections intact by using PR flow.
- Does not modify app/runtime code.