### PR TITLE
feat: add unread indicator for sessions

### DIFF
--- a/apps/backend/sentinel/app/database/migrations/0003_add_last_read_at.sql
+++ b/apps/backend/sentinel/app/database/migrations/0003_add_last_read_at.sql
@@ -1,0 +1,14 @@
+-- Add last_read_at column to sessions for unread message tracking.
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS last_read_at TIMESTAMPTZ;
+
+-- Backfill: set last_read_at to the latest message timestamp per session
+-- so existing sessions don't appear as unread.
+UPDATE sessions
+SET last_read_at = sub.latest_msg
+FROM (
+    SELECT session_id, MAX(created_at) AS latest_msg
+    FROM messages
+    GROUP BY session_id
+) sub
+WHERE sessions.id = sub.session_id
+  AND sessions.last_read_at IS NULL;

--- a/apps/backend/sentinel/app/models/sessions.py
+++ b/apps/backend/sentinel/app/models/sessions.py
@@ -29,6 +29,7 @@ class Session(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+    last_read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     messages: Mapped[list["Message"]] = relationship(back_populates="session", cascade="all, delete-orphan")
     summaries: Mapped[list["SessionSummary"]] = relationship(

--- a/apps/backend/sentinel/app/routers/sessions.py
+++ b/apps/backend/sentinel/app/routers/sessions.py
@@ -98,8 +98,12 @@ async def list_sessions(
         limit=limit,
         offset=offset,
     )
+    unread_flags = await service.compute_unread_flags(db, page.items)
     items = [
-        await _session_response(item, service, main_session_id=main_session_id)
+        await _session_response(
+            item, service, main_session_id=main_session_id,
+            has_unread=unread_flags.get(item.id, False),
+        )
         for item in page.items
     ]
     return SessionListResponse(items=items, total=page.total)
@@ -275,6 +279,22 @@ async def stop_session_generation(
     return {"status": "stopping" if cancelled else "idle"}
 
 
+@router.post("/{id}/read")
+async def mark_session_read(
+    id: UUID,
+    request: Request,
+    user: TokenPayload = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    service = _resolve_session_service(request)
+    try:
+        await service.mark_as_read(db, session_id=id, user_id=user.sub)
+    except Exception as exc:  # noqa: BLE001
+        _raise_http_for_session_error(exc)
+        raise
+    return {"status": "ok"}
+
+
 @router.post("/{id}/messages")
 async def create_message(
     id: UUID,
@@ -366,6 +386,7 @@ async def _session_response(
     service: SessionService,
     *,
     main_session_id: UUID | None = None,
+    has_unread: bool = False,
 ) -> SessionResponse:
     is_running = await service.is_session_running(session.id)
     return SessionResponse(
@@ -379,6 +400,7 @@ async def _session_response(
         started_at=session.started_at,
         is_running=is_running,
         is_main=bool(main_session_id and session.id == main_session_id),
+        has_unread=has_unread,
     )
 
 

--- a/apps/backend/sentinel/app/schemas/sessions.py
+++ b/apps/backend/sentinel/app/schemas/sessions.py
@@ -36,6 +36,7 @@ class SessionResponse(BaseModel):
     started_at: datetime
     is_running: bool = False
     is_main: bool = False
+    has_unread: bool = False
 
 
 class SessionListResponse(BaseModel):

--- a/apps/backend/sentinel/app/services/sessions/service.py
+++ b/apps/backend/sentinel/app/services/sessions/service.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func as sa_func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.config import settings
@@ -443,6 +443,52 @@ class SessionService:
 
     async def is_session_running(self, session_id: UUID) -> bool:
         return await self._run_registry.is_running(str(session_id))
+
+    async def compute_unread_flags(
+        self,
+        db: AsyncSession,
+        sessions: list[Session],
+    ) -> dict[UUID, bool]:
+        if not sessions:
+            return {}
+        session_ids = [s.id for s in sessions]
+        result = await db.execute(
+            select(
+                Message.session_id,
+                sa_func.max(Message.created_at).label("latest_msg"),
+            )
+            .where(
+                Message.session_id.in_(session_ids),
+                Message.role.in_(["assistant", "tool_result"]),
+            )
+            .group_by(Message.session_id)
+        )
+        latest_by_session: dict[UUID, datetime] = {
+            row.session_id: row.latest_msg for row in result
+        }
+        flags: dict[UUID, bool] = {}
+        for session in sessions:
+            latest_msg = latest_by_session.get(session.id)
+            if latest_msg is None:
+                flags[session.id] = False
+            elif session.last_read_at is None:
+                flags[session.id] = True
+            else:
+                flags[session.id] = latest_msg > session.last_read_at
+        return flags
+
+    async def mark_as_read(
+        self,
+        db: AsyncSession,
+        *,
+        session_id: UUID,
+        user_id: str,
+    ) -> Session:
+        session = await self.get_session(db, session_id=session_id, user_id=user_id)
+        session.last_read_at = datetime.now(UTC)
+        await db.commit()
+        await db.refresh(session)
+        return session
 
     async def get_main_session_id(self, db: AsyncSession, *, user_id: str) -> UUID | None:
         return await self._get_main_session_id(db, user_id=user_id)

--- a/apps/backend/sentinel/tests/fake_db.py
+++ b/apps/backend/sentinel/tests/fake_db.py
@@ -25,6 +25,9 @@ class _FakeResult:
     def __init__(self, rows: list):
         self._rows = rows
 
+    def __iter__(self):
+        return iter(self._rows)
+
     def scalars(self):
         return _FakeScalarResult(self._rows)
 

--- a/apps/frontend/sentinel/src/pages/SessionsPage.tsx
+++ b/apps/frontend/sentinel/src/pages/SessionsPage.tsx
@@ -372,6 +372,9 @@ const SessionRow = memo(({
       } ${multiSelectMode ? 'pl-10 pr-3' : 'pr-10'}`}
     >
       <div className="flex items-center justify-between gap-2">
+        {session.has_unread && !isActive ? (
+          <span className="h-2 w-2 shrink-0 rounded-full bg-sky-500" />
+        ) : null}
         <span className="min-w-0 flex-1 text-xs font-semibold truncate">{session.title || 'Session'}</span>
         <div className="flex shrink-0 items-center gap-1">
           {sessionChannelKind(session) === 'telegram_group' ? (
@@ -1152,6 +1155,11 @@ export function SessionsPage() {
   const onSessionClick = useCallback((id: string) => {
     setActiveSessionId(id);
     navigate(`/sessions/${id}`);
+    // Mark as read locally + server-side
+    setSessions((current) =>
+      current.map((s) => s.id === id ? { ...s, has_unread: false } : s),
+    );
+    api.post(`/sessions/${id}/read`, {}).catch(() => {/* best-effort */});
   }, [navigate]);
 
   const startResizing = useCallback((e: React.MouseEvent) => {
@@ -1198,6 +1206,12 @@ export function SessionsPage() {
     void fetchSessions();
     void fetchModels();
     void fetchLiveView();
+  }, []);
+
+  // Poll sessions every 30s to pick up unread changes
+  useEffect(() => {
+    const interval = setInterval(() => { void fetchSessions(); }, 30_000);
+    return () => clearInterval(interval);
   }, []);
 
   // Populate composer with first message from onboarding

--- a/apps/frontend/sentinel/src/types/api.ts
+++ b/apps/frontend/sentinel/src/types/api.ts
@@ -18,6 +18,7 @@ export interface Session {
   started_at: string;
   is_running: boolean;
   is_main?: boolean;
+  has_unread?: boolean;
 }
 
 export interface SessionListResponse {


### PR DESCRIPTION
## Summary
- Add `last_read_at` column to sessions with backfill migration for existing data
- Backend computes `has_unread` flag by comparing latest assistant/tool_result message against `last_read_at`
- New `POST /sessions/{id}/read` endpoint to mark sessions as read
- Frontend renders a blue dot next to sessions with unread messages (hidden when active)
- Sessions are marked read on click; 30s polling keeps the list fresh

## Test plan
- [x] Backend tests pass (`pytest tests/test_sessions.py`)
- [ ] Manual: open two sessions, send a message in one, switch to the other — blue dot should appear
- [ ] Verify migration runs cleanly on fresh and existing databases