### PR TITLE
Normalize root routes and remove trailing-slash API callers

### DIFF
--- a/apps/backend/araios/app/routers/manifest.py
+++ b/apps/backend/araios/app/routers/manifest.py
@@ -7,7 +7,7 @@ from app.database.models import Module, Permission, Setting
 router = APIRouter()
 
 
-@router.get("/")
+@router.get("")
 async def get_manifest(db: Session = Depends(get_db), _=Depends(require_permission("manifest.read"))):
     # Get base_url from settings
     setting = db.query(Setting).filter(Setting.key == "manifest_base_url").first()

--- a/apps/backend/araios/app/routers/modules.py
+++ b/apps/backend/araios/app/routers/modules.py
@@ -158,7 +158,7 @@ def _seed_module_permissions(name: str, db: Session):
 
 # ── Module CRUD ──
 
-@router.get("/")
+@router.get("")
 async def list_modules(
     db: Session = Depends(get_db),
     _: None = Depends(require_permission("modules.list")),

--- a/apps/backend/araios/app/routers/settings.py
+++ b/apps/backend/araios/app/routers/settings.py
@@ -7,7 +7,7 @@ from app.database.models import Setting
 router = APIRouter()
 
 
-@router.get("/")
+@router.get("")
 async def get_settings(db: Session = Depends(get_db), _=Depends(require_permission("settings.manage"))):
     rows = db.query(Setting).all()
     return {"settings": {r.key: r.value for r in rows}}

--- a/apps/backend/sentinel/app/routers/memory.py
+++ b/apps/backend/sentinel/app/routers/memory.py
@@ -44,7 +44,7 @@ def _raise_http_for_memory_error(exc: MemoryServiceError) -> None:
     raise exc
 
 
-@router.get("/")
+@router.get("")
 async def list_memory(
     request: Request,
     query: str | None = Query(default=None),
@@ -74,7 +74,7 @@ async def list_memory(
     )
 
 
-@router.post("/")
+@router.post("")
 async def store_memory(
     payload: StoreMemoryRequest,
     request: Request,

--- a/apps/backend/sentinel/app/routers/models.py
+++ b/apps/backend/sentinel/app/routers/models.py
@@ -10,7 +10,7 @@ from app.services.llm.factory import build_models_response
 router = APIRouter()
 
 
-@router.get("/", response_model=ModelsResponse)
+@router.get("", response_model=ModelsResponse)
 async def list_models(
     provider: LLMProvider = Depends(get_llm_provider),
 ) -> ModelsResponse:

--- a/apps/backend/sentinel/app/routers/sessions.py
+++ b/apps/backend/sentinel/app/routers/sessions.py
@@ -80,7 +80,7 @@ def _raise_http_for_session_error(exc: Exception) -> None:
     raise exc
 
 
-@router.get("/")
+@router.get("")
 async def list_sessions(
     request: Request,
     include_sub_agents: bool = Query(default=False),
@@ -105,7 +105,7 @@ async def list_sessions(
     return SessionListResponse(items=items, total=page.total)
 
 
-@router.post("/")
+@router.post("")
 async def create_session(
     request: Request,
     payload: CreateSessionRequest,

--- a/apps/backend/sentinel/app/routers/tools.py
+++ b/apps/backend/sentinel/app/routers/tools.py
@@ -23,7 +23,7 @@ _executor = ToolExecutor(_registry)
 _estop = EstopService()
 
 
-@router.get("/")
+@router.get("")
 async def list_tools(
     request: Request,
     user: TokenPayload = Depends(require_auth),

--- a/apps/backend/sentinel/app/routers/triggers.py
+++ b/apps/backend/sentinel/app/routers/triggers.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/")
+@router.get("")
 async def list_triggers(
     type: str | None = Query(default=None),
     enabled: bool | None = Query(default=None),
@@ -51,7 +51,7 @@ async def list_triggers(
     return TriggerListResponse(items=[_trigger_response(t) for t in paged], total=total)
 
 
-@router.post("/")
+@router.post("")
 async def create_trigger(
     payload: CreateTriggerRequest,
     user: TokenPayload = Depends(require_auth),

--- a/apps/frontend/sentinel/src/pages/LogsPage.tsx
+++ b/apps/frontend/sentinel/src/pages/LogsPage.tsx
@@ -1038,7 +1038,7 @@ export function LogsPage() {
       const all: Session[] = [];
       while (true) {
         const payload = await api.get<SessionListResponse>(
-          `/sessions/?limit=${pageSize}&offset=${offset}&include_sub_agents=true`,
+          `/sessions?limit=${pageSize}&offset=${offset}&include_sub_agents=true`,
         );
         const items = Array.isArray(payload?.items) ? payload.items : [];
         all.push(...items);

--- a/apps/frontend/sentinel/src/pages/SessionsPage.tsx
+++ b/apps/frontend/sentinel/src/pages/SessionsPage.tsx
@@ -1304,7 +1304,7 @@ export function SessionsPage() {
   async function fetchSessions() {
     try {
       const [payload, defaultSession] = await Promise.all([
-        api.get<SessionListResponse>('/sessions/?limit=100&offset=0&include_sub_agents=true'),
+        api.get<SessionListResponse>('/sessions?limit=100&offset=0&include_sub_agents=true'),
         api.get<Session>('/sessions/default'),
       ]);
       setDefaultSessionId(defaultSession.id);
@@ -1437,7 +1437,7 @@ export function SessionsPage() {
 
   async function fetchModels() {
     try {
-      const payload = await api.get<ModelsResponse>('/models/');
+      const payload = await api.get<ModelsResponse>('/models');
       setModels(payload.models);
       if (payload.models.length === 0) return;
       const availableTiers = new Set(payload.models.map((m) => m.tier));

--- a/apps/frontend/sentinel/src/pages/TriggersPage.tsx
+++ b/apps/frontend/sentinel/src/pages/TriggersPage.tsx
@@ -162,8 +162,8 @@ export function TriggersPage() {
     setLoading(true);
     try {
       const [triggerPayload, sessionPayload] = await Promise.all([
-        api.get<TriggerListResponse>('/triggers/?limit=100&offset=0'),
-        api.get<SessionListResponse>('/sessions/?limit=300&offset=0'),
+        api.get<TriggerListResponse>('/triggers?limit=100&offset=0'),
+        api.get<SessionListResponse>('/sessions?limit=300&offset=0'),
       ]);
       setTriggers(triggerPayload.items);
       setSessions(sessionPayload.items.filter((session) => !session.parent_session_id));
@@ -217,7 +217,7 @@ export function TriggersPage() {
 
     try {
       if (modal.mode === 'create') {
-        const created = await api.post<Trigger>('/triggers/', {
+        const created = await api.post<Trigger>('/triggers', {
           name: modal.name.trim(),
           type: modal.type,
           config,


### PR DESCRIPTION
## Summary
- Normalize root FastAPI route decorators from "/" to "" for sentinel and araios routers that are mounted with prefixes.
- Update sentinel frontend callers to use non-trailing-slash endpoints for these roots.
- Remove  query path forms that trigger avoidable redirects.

## Why
- Avoid 307 redirect behavior on prefixed APIs (notably ) that can break registry loading and onboarding/launch flows behind gateway rewrites.

## Validation
- Ran: 
- Result: 25 passed