### PR TITLE
fix(tests): use authenticated user_id in Telegram channel session guard test

### DIFF
--- a/apps/backend/sentinel/tests/test_sessions.py
+++ b/apps/backend/sentinel/tests/test_sessions.py
@@ -173,9 +173,12 @@ def test_cannot_set_telegram_channel_session_as_main():
         assert channel_resp.status_code == 200
         channel_session_id = channel_resp.json()["id"]
 
+        import jwt as _jwt
+        _decoded = _jwt.decode(token, options={"verify_signature": False})
+        _actual_user_id = _decoded["sub"]
         fake_db.add(
             SessionBinding(
-                user_id="dev-admin",
+                user_id=_actual_user_id,
                 binding_type="telegram_group",
                 binding_key="group:-100123",
                 session_id=uuid.UUID(channel_session_id),


### PR DESCRIPTION
## Problem

The test `test_cannot_set_telegram_channel_session_as_main` was failing with `assert 200 == 400`.

The test verifies that a Telegram channel-bound session cannot be set as the main session (security guard in `SessionService.set_main_session`). However, it was hardcoding `user_id="dev-admin"` in the `SessionBinding` fixture:

```python
fake_db.add(
    SessionBinding(
        user_id="dev-admin",  # ← WRONG
        ...
    )
)
```

But the admin login JWT has `sub="admin"`. So when `is_session_bound()` queried with `user_id="admin"`, it found no binding and silently returned `False` — bypassing the Telegram channel guard entirely and returning HTTP 200 instead of 400.

## Fix

Decode the JWT from the login response and use the actual `sub` claim as `user_id` in the `SessionBinding` fixture:

```python
import jwt as _jwt
_decoded = _jwt.decode(token, options={"verify_signature": False})
_actual_user_id = _decoded["sub"]
fake_db.add(
    SessionBinding(
        user_id=_actual_user_id,  # ← matches what the route sees
        ...
    )
)
```

## Test results

Before: `1 failed, 214 passed`  
After: `215 passed` ✅ — zero regressions.

---
*This fix was identified and authored by Sentinel (the AI agent running on this codebase) after reading and running the full test suite autonomously.*