### PR TITLE
feat: add str_replace_editor tool for safe file patching

### DIFF
--- a/apps/backend/sentinel/app/services/tools/builtin.py
+++ b/apps/backend/sentinel/app/services/tools/builtin.py
@@ -101,7 +101,7 @@ def build_default_registry(
     registry = ToolRegistry()
     manager = browser_manager or BrowserManager()
     registry.register(_file_read_tool())
-    registry.register(str_replace_editor_tool())
+    registry.register(str_replace_editor_tool(session_factory=session_factory))
     registry.register(_http_request_tool())
     if session_factory is not None:
         registry.register(git_accounts_available_tool(session_factory=session_factory))

--- a/apps/backend/sentinel/app/services/tools/builtin.py
+++ b/apps/backend/sentinel/app/services/tools/builtin.py
@@ -76,6 +76,7 @@ from app.services.tools.trigger_tools import (
 )
 from app.services.tools.git_accounts_available import git_accounts_available_tool
 from app.services.tools.git_exec import git_exec_tool
+from app.services.tools.editor import str_replace_editor_tool
 
 _MAX_HTTP_RESPONSE_BYTES = 1_048_576
 _ALLOWED_MEMORY_CATEGORIES = {"core", "preference", "project", "correction"}
@@ -100,6 +101,7 @@ def build_default_registry(
     registry = ToolRegistry()
     manager = browser_manager or BrowserManager()
     registry.register(_file_read_tool())
+    registry.register(str_replace_editor_tool())
     registry.register(_http_request_tool())
     if session_factory is not None:
         registry.register(git_accounts_available_tool(session_factory=session_factory))

--- a/apps/backend/sentinel/app/services/tools/editor.py
+++ b/apps/backend/sentinel/app/services/tools/editor.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Any
+from app.services.tools.executor import ToolValidationError
+from app.services.tools.registry import ToolDefinition
+from app.services.session_runtime import runtime_workspace_dir
+from uuid import UUID
+
+def str_replace_editor_tool() -> ToolDefinition:
+    async def _execute(payload: dict[str, Any]) -> dict[str, Any]:
+        session_id_raw = payload.get("session_id")
+        if not isinstance(session_id_raw, str) or not session_id_raw.strip():
+            raise ToolValidationError("Field 'session_id' must be a non-empty string")
+        try:
+            session_id = UUID(session_id_raw.strip())
+        except ValueError as exc:
+            raise ToolValidationError("Field 'session_id' must be a valid UUID string") from exc
+
+        path_raw = payload.get("path")
+        if not isinstance(path_raw, str) or not path_raw.strip():
+            raise ToolValidationError("Field 'path' must be a non-empty string")
+        
+        old_str = payload.get("old_str")
+        if not isinstance(old_str, str):
+            raise ToolValidationError("Field 'old_str' must be a string")
+            
+        new_str = payload.get("new_str")
+        if not isinstance(new_str, str):
+            raise ToolValidationError("Field 'new_str' must be a string")
+
+        workspace_dir = runtime_workspace_dir(session_id)
+        path = (workspace_dir / path_raw).resolve()
+        
+        if not path.is_relative_to(workspace_dir):
+            raise ToolValidationError(f"Path outside allowed directory: {workspace_dir}")
+
+        if not path.exists() or not path.is_file():
+            raise ToolValidationError(f"File not found: {path_raw}")
+
+        content = path.read_text(encoding="utf-8")
+        
+        count = content.count(old_str)
+        if count == 0:
+            raise ToolValidationError(f"The exact string to replace was not found in {path_raw}. Check for whitespace/indentation issues.")
+        if count > 1:
+            raise ToolValidationError(f"The string to replace occurs {count} times in {path_raw}. Please provide a more unique block of context.")
+
+        new_content = content.replace(old_str, new_str)
+        path.write_text(new_content, encoding="utf-8")
+
+        return {
+            "path": path_raw,
+            "message": "File patched successfully",
+            "old_str_count": 1
+        }
+
+    return ToolDefinition(
+        name="str_replace_editor",
+        description="Replace an exact string in a file with a new string. Requires an exact, unique match for the 'old_str'.",
+        risk_level="high",
+        parameters_schema={
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["path", "old_str", "new_str"],
+            "properties": {
+                "session_id": {"type": "string", "description": "Current session ID"},
+                "path": {"type": "string", "description": "Path to the file relative to workspace"},
+                "old_str": {"type": "string", "description": "The exact string to find in the file"},
+                "new_str": {"type": "string", "description": "The string to replace it with"}
+            },
+        },
+        execute=_execute,
+    )

--- a/apps/backend/sentinel/app/services/tools/editor.py
+++ b/apps/backend/sentinel/app/services/tools/editor.py
@@ -1,13 +1,31 @@
 from __future__ import annotations
-import os
-from pathlib import Path
 from typing import Any
-from app.services.tools.executor import ToolValidationError
-from app.services.tools.registry import ToolDefinition
-from app.services.session_runtime import runtime_workspace_dir
 from uuid import UUID
 
-def str_replace_editor_tool() -> ToolDefinition:
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models import Session
+from app.services.tools.executor import ToolValidationError
+from app.services.tools.registry import ToolDefinition
+from app.services.session_runtime import ensure_runtime_layout, runtime_workspace_dir
+
+
+async def _ensure_session_exists(
+    session_factory: async_sessionmaker[AsyncSession],
+    session_id: UUID,
+) -> None:
+    async with session_factory() as db:
+        result = await db.execute(select(Session).where(Session.id == session_id))
+        session = result.scalars().first()
+        if session is None:
+            raise ToolValidationError("Session not found")
+
+
+def str_replace_editor_tool(
+    *,
+    session_factory: async_sessionmaker[AsyncSession] | None = None,
+) -> ToolDefinition:
     async def _execute(payload: dict[str, Any]) -> dict[str, Any]:
         session_id_raw = payload.get("session_id")
         if not isinstance(session_id_raw, str) or not session_id_raw.strip():
@@ -28,6 +46,10 @@ def str_replace_editor_tool() -> ToolDefinition:
         new_str = payload.get("new_str")
         if not isinstance(new_str, str):
             raise ToolValidationError("Field 'new_str' must be a string")
+
+        if session_factory is not None:
+            await _ensure_session_exists(session_factory, session_id)
+            await ensure_runtime_layout(session_id)
 
         workspace_dir = runtime_workspace_dir(session_id)
         path = (workspace_dir / path_raw).resolve()

--- a/apps/backend/sentinel/tests/test_str_replace_editor_tool.py
+++ b/apps/backend/sentinel/tests/test_str_replace_editor_tool.py
@@ -18,7 +18,24 @@ def test_str_replace_editor_success(tmp_path: pytest.TempPathFactory, monkeypatc
 
     monkeypatch.setattr("app.services.tools.editor.runtime_workspace_dir", lambda _sid: workspace)
 
-    tool = str_replace_editor_tool()
+    class _DummyResult:
+        def scalars(self):
+            return self
+        def first(self):
+            return object()
+
+    class _DummySession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+        async def execute(self, _query):
+            return _DummyResult()
+
+    def _session_factory():
+        return _DummySession()
+
+    tool = str_replace_editor_tool(session_factory=_session_factory)
     result = asyncio.run(
         tool.execute(
             {
@@ -43,7 +60,24 @@ def test_str_replace_editor_requires_unique_match(tmp_path: pytest.TempPathFacto
 
     monkeypatch.setattr("app.services.tools.editor.runtime_workspace_dir", lambda _sid: workspace)
 
-    tool = str_replace_editor_tool()
+    class _DummyResult:
+        def scalars(self):
+            return self
+        def first(self):
+            return object()
+
+    class _DummySession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+        async def execute(self, _query):
+            return _DummyResult()
+
+    def _session_factory():
+        return _DummySession()
+
+    tool = str_replace_editor_tool(session_factory=_session_factory)
     with pytest.raises(ToolValidationError) as exc:
         asyncio.run(
             tool.execute(
@@ -68,7 +102,24 @@ def test_str_replace_editor_rejects_missing_match(tmp_path: pytest.TempPathFacto
 
     monkeypatch.setattr("app.services.tools.editor.runtime_workspace_dir", lambda _sid: workspace)
 
-    tool = str_replace_editor_tool()
+    class _DummyResult:
+        def scalars(self):
+            return self
+        def first(self):
+            return object()
+
+    class _DummySession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+        async def execute(self, _query):
+            return _DummyResult()
+
+    def _session_factory():
+        return _DummySession()
+
+    tool = str_replace_editor_tool(session_factory=_session_factory)
     with pytest.raises(ToolValidationError) as exc:
         asyncio.run(
             tool.execute(

--- a/apps/backend/sentinel/tests/test_str_replace_editor_tool.py
+++ b/apps/backend/sentinel/tests/test_str_replace_editor_tool.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from app.services.tools.editor import str_replace_editor_tool
+from app.services.tools.executor import ToolValidationError
+
+
+def test_str_replace_editor_success(tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    session_id = uuid4()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    file_path = workspace / "sample.txt"
+    file_path.write_text("hello old world", encoding="utf-8")
+
+    monkeypatch.setattr("app.services.tools.editor.runtime_workspace_dir", lambda _sid: workspace)
+
+    tool = str_replace_editor_tool()
+    result = asyncio.run(
+        tool.execute(
+            {
+                "session_id": str(session_id),
+                "path": "sample.txt",
+                "old_str": "old",
+                "new_str": "new",
+            }
+        )
+    )
+
+    assert result["message"] == "File patched successfully"
+    assert file_path.read_text(encoding="utf-8") == "hello new world"
+
+
+def test_str_replace_editor_requires_unique_match(tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    session_id = uuid4()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    file_path = workspace / "sample.txt"
+    file_path.write_text("dup dup", encoding="utf-8")
+
+    monkeypatch.setattr("app.services.tools.editor.runtime_workspace_dir", lambda _sid: workspace)
+
+    tool = str_replace_editor_tool()
+    with pytest.raises(ToolValidationError) as exc:
+        asyncio.run(
+            tool.execute(
+                {
+                    "session_id": str(session_id),
+                    "path": "sample.txt",
+                    "old_str": "dup",
+                    "new_str": "one",
+                }
+            )
+        )
+
+    assert "occurs 2 times" in str(exc.value)
+
+
+def test_str_replace_editor_rejects_missing_match(tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    session_id = uuid4()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    file_path = workspace / "sample.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    monkeypatch.setattr("app.services.tools.editor.runtime_workspace_dir", lambda _sid: workspace)
+
+    tool = str_replace_editor_tool()
+    with pytest.raises(ToolValidationError) as exc:
+        asyncio.run(
+            tool.execute(
+                {
+                    "session_id": str(session_id),
+                    "path": "sample.txt",
+                    "old_str": "zzz",
+                    "new_str": "yyy",
+                }
+            )
+        )
+
+    assert "exact string to replace was not found" in str(exc.value)


### PR DESCRIPTION
## Summary
Adds a new backend tool `str_replace_editor` for exact match file edits with workspace safety checks.

## Changes
- Added `apps/backend/sentinel/app/services/tools/editor.py`
  - New tool: `str_replace_editor`
  - Validates session id, path, and exact unique match of `old_str`
  - Enforces workspace only file access
- Updated `apps/backend/sentinel/app/services/tools/builtin.py`
  - Imported `str_replace_editor_tool`
  - Registered it in default tool registry

## Why
Provides a structured and safer edit primitive for LLM driven code changes.
