### PR TITLE
fix(ci): install backend dev deps via PEP 735 --group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y bubblewrap
-          python -m pip install --upgrade pip
-          python -m pip install -e "apps/backend/sentinel[dev]"
+          python -m pip install --upgrade "pip>=25.1"
+          python -m pip install -e "apps/backend/sentinel" --group ./apps/backend/sentinel/pyproject.toml:dev
 
       - name: Test backend
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           cd apps/backend/sentinel
           python -m compileall app tests
-          python -m pytest tests/test_auth_flow.py tests/test_validation.py tests/test_memory.py tests/test_tools.py tests/test_onboarding.py tests/test_playwright.py -q
+          python -m pytest tests/test_auth_flow.py tests/test_validation.py tests/test_memory.py tests/test_tools.py tests/test_onboarding.py tests/test_playwright_runtime.py -q
 
   frontend-build:
     name: Frontend Build


### PR DESCRIPTION
## Summary
- Backend dev deps were migrated to `[dependency-groups].dev` in `apps/backend/sentinel/pyproject.toml`, but CI still installs with `pip install -e "...[dev]"` — that syntax only reads `[project.optional-dependencies]`, so `pytest` was no longer being installed and Backend Tests failed with `No module named pytest`.
- Upgrade CI's pip to `>=25.1` (which added native PEP 735 support) and install the `dev` group via `--group ./apps/backend/sentinel/pyproject.toml:dev`.
- Keeps `[dependency-groups]` as the single source of truth for dev deps; no package config regression.

## Test plan
- [ ] CI Backend Tests job goes green on this PR