### PR TITLE
feat(frontend): tiling workspace + unified pane-header actions

### DIFF
--- a/apps/frontend/sentinel/package-lock.json
+++ b/apps/frontend/sentinel/package-lock.json
@@ -17,6 +17,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "clsx": "^2.1.1",
+        "dockview-react": "^6.6.1",
         "katex": "^0.17.0",
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",
@@ -824,9 +825,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -844,9 +842,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -864,9 +859,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -884,9 +876,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -904,9 +893,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -924,9 +910,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1731,6 +1714,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dockview": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/dockview/-/dockview-6.6.1.tgz",
+      "integrity": "sha512-vBnxWVk0f665z1Zyx598l/BMUjHD3SK5V4XorxpYGjaSREM8lLc8O6ylgKTtw+ZnCOMYOhcwov9x0ubfFazvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "dockview-core": "^6.6.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/dockview-core": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/dockview-core/-/dockview-core-6.6.1.tgz",
+      "integrity": "sha512-WuNoO2wl3rGI8MaTuvmfgViek4WafHLD9Kf//Hw69g8TgAHSpAWr6RW15kU6U9vwtQxIi/YBxQNcIA5RzQ46Fw==",
+      "license": "MIT"
+    },
+    "node_modules/dockview-react": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/dockview-react/-/dockview-react-6.6.1.tgz",
+      "integrity": "sha512-zF/CQzAxjA2mlSTnDt2rbBe49uG33mvg1DPitNCPrIhhDulyiiBG1A1pRyjVx4MJbVh1xx5gAYbNRwu+mCR7CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dockview": "^6.6.1"
+      }
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -2511,9 +2521,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2535,9 +2542,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2559,9 +2563,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2583,9 +2584,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/apps/frontend/sentinel/package.json
+++ b/apps/frontend/sentinel/package.json
@@ -23,6 +23,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "clsx": "^2.1.1",
+    "dockview-react": "^6.6.1",
     "katex": "^0.17.0",
     "lucide-react": "^1.17.0",
     "react": "^19.2.6",

--- a/apps/frontend/sentinel/src/App.tsx
+++ b/apps/frontend/sentinel/src/App.tsx
@@ -110,9 +110,12 @@ function WorkspaceRoute() {
   // live DockviewApi to be bound, so retry across frames until it takes.
   useEffect(() => {
     const store = useWorkspaceStore.getState();
-    // A persisted layout (even empty) means the user has a saved arrangement —
-    // never override it.
-    if (store.layout) return;
+    // Whether a pane already exists is tracked by openTabs (rebuilt from the
+    // restored layout on bind), not by `layout`: binding the live api eagerly
+    // persists a non-null *empty* layout via toJSON(), so `layout` is truthy
+    // even with zero panes. Keying off openTabs avoids that false positive,
+    // which previously made the seed bail and leave the workspace empty.
+    if (Object.keys(store.openTabs).length > 0) return;
 
     let cancelled = false;
     let frame = 0;
@@ -120,7 +123,7 @@ function WorkspaceRoute() {
       if (cancelled) return;
       const current = useWorkspaceStore.getState();
       // The user (or restore) may have created panes between frames; bail if so.
-      if (current.layout || Object.keys(current.openTabs).length > 0) return;
+      if (Object.keys(current.openTabs).length > 0) return;
       const paneId = current.openTab('sessions');
       if (paneId === null) {
         // No api bound yet; try again next frame (cap to avoid a runaway loop).

--- a/apps/frontend/sentinel/src/App.tsx
+++ b/apps/frontend/sentinel/src/App.tsx
@@ -1,8 +1,10 @@
 import { Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { Navigate, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Toaster } from 'sonner';
 
+import { AppShell } from './components/AppShell';
+import { Workspace } from './components/workspace/Workspace';
 import { Logo } from './components/ui/Logo';
 import { AdminPage } from './pages/AdminPage';
 import { LogsPage } from './pages/LogsPage';
@@ -20,6 +22,7 @@ import { ModulesPage } from './pages/ModulesPage';
 import { instanceRouteFromPath } from './lib/routes';
 import { useAuthStore } from './store/auth-store';
 import { useThemeStore } from './store/theme-store';
+import { useWorkspaceStore } from './store/workspace-store';
 import { api } from './lib/api';
 
 function FullPageLoader() {
@@ -92,6 +95,59 @@ function TriggerDetailRedirect() {
   return <Navigate to={instanceRouteFromPath(location.pathname, 'triggers')} replace />;
 }
 
+/**
+ * Instance workspace: the tiling container fills the AppShell content area and
+ * the left nav acts as a tab launcher (see AppShell launcher mode). The header
+ * is hidden so dockview owns the full content region; the persisted layout is
+ * rehydrated by <Workspace/> itself on mount.
+ */
+function WorkspaceRoute() {
+  const { instanceName } = useParams<{ instanceName?: string }>();
+
+  // Seed a sensible default layout (a single Sessions pane) the first time the
+  // workspace is opened with nothing persisted. <Workspace/> restores any saved
+  // layout in its onReady; we only step in when there is none. openTab needs the
+  // live DockviewApi to be bound, so retry across frames until it takes.
+  useEffect(() => {
+    const store = useWorkspaceStore.getState();
+    // A persisted layout (even empty) means the user has a saved arrangement —
+    // never override it.
+    if (store.layout) return;
+
+    let cancelled = false;
+    let frame = 0;
+    const trySeed = () => {
+      if (cancelled) return;
+      const current = useWorkspaceStore.getState();
+      // The user (or restore) may have created panes between frames; bail if so.
+      if (current.layout || Object.keys(current.openTabs).length > 0) return;
+      const paneId = current.openTab('sessions');
+      if (paneId === null) {
+        // No api bound yet; try again next frame (cap to avoid a runaway loop).
+        if (frame < 60) {
+          frame += 1;
+          requestAnimationFrame(trySeed);
+        }
+      }
+    };
+    requestAnimationFrame(trySeed);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <AppShell
+      title="Workspace"
+      subtitle={instanceName}
+      hideHeader
+      contentClassName="h-full !p-0 overflow-hidden"
+    >
+      <Workspace instanceName={instanceName} />
+    </AppShell>
+  );
+}
+
 export default function App() {
   const initialize = useAuthStore((state) => state.initialize);
   const initializeTheme = useThemeStore((state) => state.initializeTheme);
@@ -109,6 +165,8 @@ export default function App() {
 
         <Route element={<AuthenticatedOutlet />}>
           <Route path="/" element={<InstancePickerPage />} />
+          <Route path="/instances/:instanceName" element={<Navigate to="workspace" replace />} />
+          <Route path="/instances/:instanceName/workspace" element={<WorkspaceRoute />} />
           <Route path="/instances/:instanceName/sessions" element={<SessionsPage />} />
           <Route path="/instances/:instanceName/sessions/:id" element={<SessionsPage />} />
           <Route path="/instances/:instanceName/onboarding" element={<OnboardingPage />} />

--- a/apps/frontend/sentinel/src/components/AppShell.tsx
+++ b/apps/frontend/sentinel/src/components/AppShell.tsx
@@ -16,6 +16,9 @@ import {
   LayoutGrid,
   CheckCircle,
   Lock,
+  Globe,
+  Terminal,
+  Folder,
 } from 'lucide-react';
 
 import { APP_VERSION } from '../lib/env';
@@ -43,6 +46,9 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { label: 'Sessions', route: 'sessions', icon: LayoutDashboard },
+  { label: 'Desktop', route: 'desktop', icon: Globe },
+  { label: 'Terminal', route: 'terminal', icon: Terminal },
+  { label: 'Files', route: 'files', icon: Folder },
   { label: 'Session Logs', route: 'logs', icon: Activity },
   { label: 'Memory', route: 'memory', icon: Database },
   { label: 'Triggers', route: 'triggers', icon: Zap },

--- a/apps/frontend/sentinel/src/components/AppShell.tsx
+++ b/apps/frontend/sentinel/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactNode, useState } from 'react';
+import { PropsWithChildren, ReactNode, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   LayoutDashboard,
@@ -27,6 +27,9 @@ import { useWorkspaceMode } from '../lib/workspace-context';
 import { isWorkspaceTabId } from '../lib/workspace-tabs';
 import { useOpenTabIds, useWorkspaceStore } from '../store/workspace-store';
 import { useThemeStore } from '../store/theme-store';
+import { clearPaneActions, setPaneActions } from '../store/pane-actions-store';
+import { usePaneId } from './workspace/WorkspacePane';
+import { SidebarInstanceSwitcher } from './SidebarInstanceSwitcher';
 import { Logo } from './ui/Logo';
 
 interface AppShellProps extends PropsWithChildren {
@@ -83,8 +86,22 @@ export function AppShell({
   const openTabIds = useOpenTabIds();
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const paneId = usePaneId();
   const instanceMatch = location.pathname.match(/^\/instances\/([^/]+)/);
   const hasInstanceScope = Boolean(instanceMatch?.[1]);
+
+  // In a tiling-workspace pane the page's header actions render inside the
+  // pane's own tab ({@link PaneHeaderTab}), not in a second header bar here.
+  // The tab lives in a separate React tree, so we bridge the `actions` node
+  // through the pane-actions store keyed by `paneId`. The store is consumed by
+  // the tab (a different component tree), so this write never re-renders this
+  // AppShell — no update loop. Depend only on [paneId, actions]; clear on
+  // unmount or when the pane id changes so a closed pane leaves no stale node.
+  useEffect(() => {
+    if (!workspaceMode || !paneId) return;
+    setPaneActions(paneId, actions ?? null);
+    return () => clearPaneActions(paneId);
+  }, [paneId, actions, workspaceMode]);
 
   // When the shell is hosting the tiling workspace, the left nav acts as a tab
   // launcher: clicking an item opens/focuses that pane instead of navigating to
@@ -140,17 +157,12 @@ export function AppShell({
 
   // Inside a tiling workspace pane the global chrome (sidebar + header) is
   // already provided by the outer shell hosting <Workspace/>, and the pane
-  // supplies its own header (tab picker / split / close). Pages still wrap their
-  // body in <AppShell> for the route case, so here we collapse to bare content
-  // and let the optional header actions ride along in a slim strip.
+  // supplies its own header (tab picker / actions / split / close). The page's
+  // `actions` are registered into the pane-actions store above and rendered by
+  // the pane's tab, so here we render bare content with NO header bar.
   if (workspaceMode) {
     return (
       <div className="flex h-full w-full flex-col overflow-hidden bg-[color:var(--app-bg)] text-[color:var(--text-primary)]">
-        {!hideHeader && actions && (
-          <div className="flex shrink-0 items-center justify-end gap-2 border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] px-4 py-2">
-            {actions}
-          </div>
-        )}
         <main className={`flex-1 overflow-y-auto p-4 md:p-6 ${contentClassName}`}>
           {children}
         </main>
@@ -182,6 +194,8 @@ export function AppShell({
             </div>
           </div>
         </div>
+
+        {hasInstanceScope && <SidebarInstanceSwitcher expanded={isSidebarExpanded} />}
 
         {hasInstanceScope ? renderNav(navItems) : <div className="flex-1" />}
 
@@ -251,6 +265,7 @@ export function AppShell({
                 <X size={20} />
               </button>
             </div>
+            {hasInstanceScope && <SidebarInstanceSwitcher expanded />}
             {hasInstanceScope ? renderNav(navItems, () => setIsMobileMenuOpen(false)) : <div className="flex-1" />}
             <div className="p-4 border-t border-[color:var(--border-subtle)]">
               <button

--- a/apps/frontend/sentinel/src/components/AppShell.tsx
+++ b/apps/frontend/sentinel/src/components/AppShell.tsx
@@ -19,7 +19,10 @@ import {
 } from 'lucide-react';
 
 import { APP_VERSION } from '../lib/env';
-import { instanceRouteFromPath } from '../lib/routes';
+import { instancePrefixFromPath, instanceRouteFromPath } from '../lib/routes';
+import { useWorkspaceMode } from '../lib/workspace-context';
+import { isWorkspaceTabId } from '../lib/workspace-tabs';
+import { useOpenTabIds, useWorkspaceStore } from '../store/workspace-store';
 import { useThemeStore } from '../store/theme-store';
 import { Logo } from './ui/Logo';
 
@@ -67,22 +70,49 @@ export function AppShell({
 }: AppShellProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  const workspaceMode = useWorkspaceMode();
   const theme = useThemeStore((state) => state.theme);
   const toggleTheme = useThemeStore((state) => state.toggleTheme);
+  const openTab = useWorkspaceStore((state) => state.openTab);
+  const openTabIds = useOpenTabIds();
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const instanceMatch = location.pathname.match(/^\/instances\/([^/]+)/);
   const hasInstanceScope = Boolean(instanceMatch?.[1]);
 
+  // When the shell is hosting the tiling workspace, the left nav acts as a tab
+  // launcher: clicking an item opens/focuses that pane instead of navigating to
+  // a standalone page. Detected by the dedicated `/workspace` route.
+  const instancePrefix = instancePrefixFromPath(location.pathname);
+  const workspaceRoute = instancePrefix ? `${instancePrefix}/workspace` : null;
+  const launcherMode = Boolean(workspaceRoute) && location.pathname === workspaceRoute;
+
+  // A nav item launches a workspace tab when we are in launcher mode and the
+  // item's route maps to a real workspace tab id (e.g. dev-only `showcase` has
+  // no tab, so it always router-navigates).
+  const handleNavClick = (item: NavItem, onNavigate?: () => void) => {
+    if (launcherMode && isWorkspaceTabId(item.route)) {
+      openTab(item.route);
+      onNavigate?.();
+      return;
+    }
+    navigate(instanceRouteFromPath(location.pathname, item.route));
+    onNavigate?.();
+  };
+
   const renderNav = (items: NavItem[], onNavigate?: () => void) => (
     <nav className="flex-1 overflow-y-auto overflow-x-hidden py-4 px-2 space-y-1">
       {items.map((item) => {
         const itemPath = instanceRouteFromPath(location.pathname, item.route);
-        const active = isActive(location.pathname, itemPath);
+        // In launcher mode the "active" cue follows which tabs are open rather
+        // than the URL (which stays on `/workspace`).
+        const active = launcherMode
+          ? isWorkspaceTabId(item.route) && openTabIds.includes(item.route)
+          : isActive(location.pathname, itemPath);
         return (
           <button
             key={item.route}
-            onClick={() => { navigate(itemPath); onNavigate?.(); }}
+            onClick={() => handleNavClick(item, onNavigate)}
             className={`group flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
               active
                 ? 'bg-[color:var(--surface-accent)] text-[color:var(--text-primary)]'
@@ -101,6 +131,26 @@ export function AppShell({
       })}
     </nav>
   );
+
+  // Inside a tiling workspace pane the global chrome (sidebar + header) is
+  // already provided by the outer shell hosting <Workspace/>, and the pane
+  // supplies its own header (tab picker / split / close). Pages still wrap their
+  // body in <AppShell> for the route case, so here we collapse to bare content
+  // and let the optional header actions ride along in a slim strip.
+  if (workspaceMode) {
+    return (
+      <div className="flex h-full w-full flex-col overflow-hidden bg-[color:var(--app-bg)] text-[color:var(--text-primary)]">
+        {!hideHeader && actions && (
+          <div className="flex shrink-0 items-center justify-end gap-2 border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] px-4 py-2">
+            {actions}
+          </div>
+        )}
+        <main className={`flex-1 overflow-y-auto p-4 md:p-6 ${contentClassName}`}>
+          {children}
+        </main>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-screen w-full overflow-hidden bg-[color:var(--app-bg)] text-[color:var(--text-primary)]">

--- a/apps/frontend/sentinel/src/components/SidebarInstanceSwitcher.tsx
+++ b/apps/frontend/sentinel/src/components/SidebarInstanceSwitcher.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Check, ChevronDown, Home, Server } from 'lucide-react';
+
+import { api } from '../lib/api';
+import { instanceRoute } from '../lib/routes';
+import { useInstanceName } from '../lib/workspace-context';
+
+interface SentinelInstance {
+  name: string;
+  database_name: string;
+  display_name: string | null;
+  runtime_id: string | null;
+}
+
+interface SidebarInstanceSwitcherProps {
+  /** Mirrors the sidebar hover-expand state so labels fade in/out in sync. */
+  expanded: boolean;
+}
+
+/**
+ * App-level instance switcher + Home button for the left sidebar. Present in
+ * both normal and workspace modes (the sidebar is global chrome), so global
+ * navigation lives here instead of being duplicated in per-page/per-pane
+ * headers. Selecting an instance navigates to that instance's `/workspace`
+ * route; Home returns to the instance picker at `/`.
+ */
+export function SidebarInstanceSwitcher({ expanded }: SidebarInstanceSwitcherProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const activeInstanceName = useInstanceName() ?? null;
+
+  const [instances, setInstances] = useState<SentinelInstance[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [menuRect, setMenuRect] = useState<{ left: number; top: number; width: number } | null>(null);
+
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  // Only show the switcher once we are scoped to an instance; outside an
+  // instance scope (e.g. the `/` picker) there is nothing to switch.
+  const hasInstanceScope = Boolean(activeInstanceName);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!hasInstanceScope) {
+      setInstances([]);
+      return;
+    }
+    api
+      .get<SentinelInstance[]>('/instances')
+      .then((list) => {
+        if (!cancelled) setInstances(list);
+      })
+      .catch(() => {
+        if (!cancelled) setInstances([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [hasInstanceScope]);
+
+  const activeInstance = instances.find((instance) => instance.name === activeInstanceName) ?? null;
+  const label =
+    activeInstance?.display_name?.trim() ||
+    activeInstance?.name ||
+    activeInstanceName ||
+    'Instance';
+
+  const updateMenuRect = useCallback(() => {
+    const button = buttonRef.current;
+    if (!button) return;
+    const rect = button.getBoundingClientRect();
+    setMenuRect({
+      left: rect.left,
+      top: rect.bottom + 6,
+      width: rect.width,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    updateMenuRect();
+    const handleReposition = () => updateMenuRect();
+    window.addEventListener('resize', handleReposition);
+    window.addEventListener('scroll', handleReposition, true);
+    return () => {
+      window.removeEventListener('resize', handleReposition);
+      window.removeEventListener('scroll', handleReposition, true);
+    };
+  }, [isOpen, updateMenuRect]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (buttonRef.current?.contains(target)) return;
+      if (menuRef.current?.contains(target)) return;
+      setIsOpen(false);
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [isOpen]);
+
+  // Close the menu whenever the route changes (a selection navigated away).
+  useEffect(() => {
+    setIsOpen(false);
+  }, [location.pathname]);
+
+  if (!hasInstanceScope) return null;
+
+  const onSelectInstance = (instanceName: string) => {
+    setIsOpen(false);
+    if (instanceName === activeInstanceName) return;
+    navigate(instanceRoute(instanceName, 'workspace'));
+  };
+
+  const labelClass = `transition-opacity duration-200 whitespace-nowrap ${
+    expanded ? 'opacity-100' : 'opacity-0 pointer-events-none'
+  }`;
+
+  return (
+    <div className="px-2 pt-3 space-y-1">
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        onClick={() => {
+          updateMenuRect();
+          setIsOpen((open) => !open);
+        }}
+        className="group flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)] transition-colors"
+      >
+        <Server
+          size={18}
+          className="shrink-0 text-[color:var(--text-muted)] transition-colors group-hover:text-[color:var(--text-primary)]"
+        />
+        <span className={`min-w-0 flex-1 truncate text-left ${labelClass}`}>{label}</span>
+        <ChevronDown
+          size={14}
+          aria-hidden="true"
+          className={`shrink-0 text-[color:var(--text-muted)] transition-[transform,opacity] duration-200 ${
+            expanded ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          } ${isOpen ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      <button
+        type="button"
+        onClick={() => navigate('/')}
+        className="group flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)] transition-colors"
+      >
+        <Home
+          size={18}
+          className="shrink-0 text-[color:var(--text-muted)] transition-colors group-hover:text-[color:var(--text-primary)]"
+        />
+        <span className={labelClass}>Home</span>
+      </button>
+
+      {isOpen && menuRect &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="listbox"
+            aria-label="Switch instance"
+            style={{
+              left: menuRect.left,
+              top: menuRect.top,
+              width: Math.max(menuRect.width, 240),
+            }}
+            className="fixed z-[10000] max-h-80 overflow-y-auto rounded-2xl border border-[color:var(--border-strong)] bg-[color:var(--surface-0)] py-1.5 shadow-2xl backdrop-blur-xl animate-in fade-in zoom-in-95 duration-150 origin-top-left"
+          >
+            {instances.length === 0 ? (
+              <div className="px-3 py-3 text-xs text-[color:var(--text-muted)]">No instances</div>
+            ) : (
+              instances.map((instance) => {
+                const title = (instance.display_name || instance.name).trim() || instance.name;
+                const active = instance.name === activeInstanceName;
+                return (
+                  <button
+                    key={instance.name}
+                    type="button"
+                    role="option"
+                    aria-selected={active}
+                    onClick={() => onSelectInstance(instance.name)}
+                    className={`group flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+                      active
+                        ? 'bg-[color:var(--surface-accent)] text-[color:var(--text-primary)]'
+                        : 'text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]'
+                    }`}
+                  >
+                    <div
+                      className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                        active
+                          ? 'bg-[color:var(--accent-solid)]'
+                          : 'bg-[color:var(--text-muted)]/35 group-hover:bg-[color:var(--text-secondary)]'
+                      }`}
+                    />
+                    <span className="min-w-0 flex-1 truncate text-xs font-semibold">{title}</span>
+                    {active && <Check size={13} className="shrink-0 text-[color:var(--accent-solid)]" />}
+                  </button>
+                );
+              })
+            )}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/apps/frontend/sentinel/src/components/ui/HeaderActions.tsx
+++ b/apps/frontend/sentinel/src/components/ui/HeaderActions.tsx
@@ -1,0 +1,171 @@
+import { clsx } from 'clsx';
+import { forwardRef } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+// Compact header-action controls. These render inside the ~40px tiling pane
+// header (between the view-switcher and split/close) as well as standalone in
+// the full 64px page header (non-workspace mode), so the chrome is intentionally
+// subtle and small. Sentence-case labels, h-7 height, text-xs.
+
+const COMPACT_BASE =
+  'inline-flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium ' +
+  'shadow-sm transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50';
+
+// Idle utility surface: a faint top-down surface gradient + a slightly stronger
+// idle border so the control reads as a real, tappable chip rather than a flat
+// grey rectangle. Hover bumps the surface/border.
+const UTILITY_IDLE =
+  'text-[color:var(--text-secondary)] border border-[color:var(--border-strong)] ' +
+  'bg-gradient-to-b from-[color:var(--surface-1)] to-[color:var(--surface-2)] ' +
+  'hover:from-[color:var(--surface-2)] hover:to-[color:var(--surface-2)] ' +
+  'hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)]';
+
+// Toggled-on / selected utility state: subtle accent surface so it reads as
+// "active" without the heavy fill of the primary button.
+const UTILITY_ACTIVE =
+  'text-[color:var(--accent-solid)] bg-[color:var(--surface-2)] border border-[color:var(--accent-solid)]/40 ' +
+  'hover:bg-[color:var(--surface-2)] hover:border-[color:var(--accent-solid)]/60';
+
+// Pill family for dropdown triggers: the original rounded-full Sessions pill the
+// user liked — soft surface, colored leading icon (via `iconClassName`), shadow.
+const PILL_BASE =
+  'inline-flex h-7 items-center gap-2 rounded-full px-3 text-[11px] font-semibold ' +
+  'shadow-sm transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50';
+
+const PILL_IDLE =
+  'text-[color:var(--text-primary)] border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] ' +
+  'hover:bg-[color:var(--surface-2)] hover:border-[color:var(--border-strong)]';
+
+const PILL_ACTIVE =
+  'text-[color:var(--text-primary)] border border-[color:var(--border-strong)] bg-[color:var(--surface-2)]';
+
+type ButtonBaseProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'>;
+
+export interface HeaderActionButtonProps extends ButtonBaseProps {
+  /** Leading icon (already sized by the caller, e.g. lucide icon at size ~14). */
+  icon?: ReactNode;
+  /** Sentence-case label. Omit for an icon-only square button. */
+  label?: ReactNode;
+  /** Renders the toggled-on / selected accent state. */
+  active?: boolean;
+  /** Optional tint for the leading icon wrapper (e.g. `text-amber-500/80`). */
+  iconClassName?: string;
+}
+
+/**
+ * Utility / secondary compact header button. Supports icon + label, an icon-only
+ * mode (omit `label`), and an `active` toggle state. Forwards its ref so it can
+ * double as a `useAnchorRect` anchor for a portaled dropdown menu.
+ */
+export const HeaderActionButton = forwardRef<HTMLButtonElement, HeaderActionButtonProps>(
+  function HeaderActionButton({ icon, label, active = false, iconClassName, className, type, ...rest }, ref) {
+    const iconOnly = label == null;
+    return (
+      <button
+        ref={ref}
+        type={type ?? 'button'}
+        className={clsx(
+          COMPACT_BASE,
+          active ? UTILITY_ACTIVE : UTILITY_IDLE,
+          iconOnly && 'w-7 justify-center px-0',
+          className,
+        )}
+        {...rest}
+      >
+        {icon != null && (
+          <span className={clsx('inline-flex shrink-0', !active && iconClassName)}>{icon}</span>
+        )}
+        {label}
+      </button>
+    );
+  },
+);
+
+export interface HeaderPrimaryButtonProps extends ButtonBaseProps {
+  icon?: ReactNode;
+  label?: ReactNode;
+}
+
+/**
+ * The page's main create/affirmative action. Same compact size as the utility
+ * button but filled with the accent color, with a faint top sheen + shadow so it
+ * has a touch more depth than a flat fill.
+ */
+export const HeaderPrimaryButton = forwardRef<HTMLButtonElement, HeaderPrimaryButtonProps>(
+  function HeaderPrimaryButton({ icon, label, className, type, ...rest }, ref) {
+    return (
+      <button
+        ref={ref}
+        type={type ?? 'button'}
+        className={clsx(
+          COMPACT_BASE,
+          'bg-[color:var(--accent-solid)] text-[color:var(--app-bg)] border border-[color:var(--accent-solid)] ' +
+            'shadow-[0_1px_2px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.18)] hover:opacity-90',
+          label == null && 'w-7 justify-center px-0',
+          className,
+        )}
+        {...rest}
+      >
+        {icon}
+        {label}
+      </button>
+    );
+  },
+);
+
+/** Thin vertical divider between compact action groups. */
+export function HeaderActionDivider({ className }: { className?: string }) {
+  return <div className={clsx('h-4 w-px bg-[color:var(--border-subtle)]', className)} aria-hidden="true" />;
+}
+
+export interface HeaderActionDropdownProps extends ButtonBaseProps {
+  icon?: ReactNode;
+  /** Current value shown in the pill. */
+  label?: ReactNode;
+  /** Drives the chevron rotation. */
+  open?: boolean;
+  active?: boolean;
+  /** Tint for the leading icon (e.g. `text-emerald-500/80`) — the colored dot the user liked. */
+  iconClassName?: string;
+}
+
+/**
+ * Compact dropdown trigger — the original rounded-full Sessions pill: soft
+ * surface, a colored leading icon (`iconClassName`), value label, and a rotating
+ * chevron. Restyles the existing Effort / Agent-mode / Max triggers; the portaled
+ * menu they open is owned by the caller. Forwards its ref so the caller can pass
+ * it (or a wrapping ref) to `useAnchorRect`.
+ */
+export const HeaderActionDropdown = forwardRef<HTMLButtonElement, HeaderActionDropdownProps>(
+  function HeaderActionDropdown(
+    { icon, label, open = false, active = false, iconClassName, className, type, ...rest },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type={type ?? 'button'}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className={clsx(
+          PILL_BASE,
+          open || active ? PILL_ACTIVE : PILL_IDLE,
+          className,
+        )}
+        {...rest}
+      >
+        {icon != null && (
+          <span className={clsx('inline-flex shrink-0', iconClassName ?? 'text-[color:var(--text-secondary)]')}>
+            {icon}
+          </span>
+        )}
+        {label != null && <span className="truncate">{label}</span>}
+        <ChevronDown
+          size={13}
+          className={clsx('opacity-50 transition-transform duration-200', open && 'rotate-180')}
+        />
+      </button>
+    );
+  },
+);

--- a/apps/frontend/sentinel/src/components/workspace/PaneHeaderTab.tsx
+++ b/apps/frontend/sentinel/src/components/workspace/PaneHeaderTab.tsx
@@ -1,12 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-  type SyntheticEvent,
-} from 'react';
+import { useRef, useState, type CSSProperties, type SyntheticEvent } from 'react';
 import { createPortal } from 'react-dom';
 import type { IDockviewPanelHeaderProps } from 'dockview-react';
 import {
@@ -29,6 +21,8 @@ import {
   type WorkspacePaneParams,
   type SplitDirection,
 } from '../../store/workspace-store';
+import { usePaneActions } from '../../store/pane-actions-store';
+import { useAnchorRect, useDismissOnOutside } from '../../lib/portal-menu';
 
 /** Read the current `tabId` off the panel params, validated against the registry. */
 function readTabId(params: Partial<WorkspacePaneParams> | undefined): WorkspaceTabId | null {
@@ -56,80 +50,6 @@ const DRAG_BLOCKERS = {
   onPointerDown: blockDrag,
   onMouseDown: blockDrag,
 } as const;
-
-interface MenuRect {
-  top: number;
-  left: number;
-  /** Width of the trigger, so the menu can size/align relative to it. */
-  triggerWidth: number;
-}
-
-/**
- * Track the viewport rect of a trigger element while `open`, recomputing on
- * open and on scroll/resize so a menu portaled to `document.body` (position:
- * fixed) stays glued to its trigger. Returns null while closed.
- */
-function useAnchorRect(
-  triggerRef: React.RefObject<HTMLElement | null>,
-  open: boolean,
-): MenuRect | null {
-  const [rect, setRect] = useState<MenuRect | null>(null);
-
-  const measure = useCallback(() => {
-    const el = triggerRef.current;
-    if (!el) return;
-    const r = el.getBoundingClientRect();
-    setRect({ top: r.bottom, left: r.left, triggerWidth: r.width });
-  }, [triggerRef]);
-
-  useLayoutEffect(() => {
-    if (!open) {
-      setRect(null);
-      return;
-    }
-    measure();
-    // Capture-phase scroll catches nested scroll containers (e.g. a pane body).
-    window.addEventListener('scroll', measure, true);
-    window.addEventListener('resize', measure);
-    return () => {
-      window.removeEventListener('scroll', measure, true);
-      window.removeEventListener('resize', measure);
-    };
-  }, [open, measure]);
-
-  return rect;
-}
-
-/**
- * Close `open` when a pointer goes down outside both the trigger and the
- * portaled menu. Both refs are checked because the menu lives in document.body,
- * outside the trigger's DOM subtree.
- */
-function useDismissOnOutside(
-  open: boolean,
-  setOpen: (value: boolean) => void,
-  triggerRef: React.RefObject<HTMLElement | null>,
-  menuRef: React.RefObject<HTMLElement | null>,
-) {
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (triggerRef.current?.contains(target)) return;
-      if (menuRef.current?.contains(target)) return;
-      setOpen(false);
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false);
-    };
-    document.addEventListener('mousedown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
-    };
-  }, [open, setOpen, triggerRef, menuRef]);
-}
 
 export interface TabPickerProps {
   paneId: string;
@@ -388,13 +308,28 @@ export function PaneHeaderTab(props: IDockviewPanelHeaderProps<WorkspacePanePara
   const paneId = props.api.id;
   const tabId = readTabId(props.params);
   const closePane = useWorkspaceStore((state) => state.closePane);
+  // The hosted page registers its header actions under this pane id (the page's
+  // AppShell and this tab live in separate React trees, bridged by the store).
+  const actions = usePaneActions(paneId);
 
   return (
-    <div className="flex h-full w-full items-center justify-between gap-2 border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] px-2 text-[color:var(--text-primary)]">
-      <div className="flex min-w-0 items-center gap-1">
+    <div className="flex h-full w-full items-center gap-2 border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] px-2 text-[color:var(--text-primary)]">
+      <div className="flex min-w-0 shrink-0 items-center gap-1">
         <TabPicker paneId={paneId} activeTabId={tabId} variant="header" />
       </div>
-      <div className="flex shrink-0 items-center gap-0.5">
+      {actions != null && (
+        // The page's interactive action buttons. Drag-block here (same backends
+        // as the split/close controls) so clicking an action never arms a pane
+        // drag. Min-w-0 + scroll-x lets a crowded action set shrink/scroll
+        // without pushing the split/close controls out of the bar.
+        <div
+          {...DRAG_BLOCKERS}
+          className="flex min-w-0 flex-1 items-center justify-end gap-1.5 overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
+          {actions}
+        </div>
+      )}
+      <div className={`flex shrink-0 items-center gap-0.5 ${actions != null ? '' : 'ml-auto'}`}>
         <SplitMenu paneId={paneId} />
         <button
           type="button"

--- a/apps/frontend/sentinel/src/components/workspace/PaneHeaderTab.tsx
+++ b/apps/frontend/sentinel/src/components/workspace/PaneHeaderTab.tsx
@@ -1,0 +1,411 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type SyntheticEvent,
+} from 'react';
+import { createPortal } from 'react-dom';
+import type { IDockviewPanelHeaderProps } from 'dockview-react';
+import {
+  ChevronDown,
+  Check,
+  SplitSquareHorizontal,
+  SplitSquareVertical,
+  X,
+} from 'lucide-react';
+
+import {
+  WORKSPACE_TABS,
+  getWorkspaceTab,
+  isWorkspaceTabId,
+  type WorkspaceTabId,
+} from '../../lib/workspace-tabs';
+import {
+  useWorkspaceStore,
+  useOpenTabIds,
+  type WorkspacePaneParams,
+  type SplitDirection,
+} from '../../store/workspace-store';
+
+/** Read the current `tabId` off the panel params, validated against the registry. */
+function readTabId(params: Partial<WorkspacePaneParams> | undefined): WorkspaceTabId | null {
+  const raw = params?.tabId;
+  if (typeof raw === 'string' && isWorkspaceTabId(raw)) {
+    return raw;
+  }
+  return null;
+}
+
+/**
+ * Stop a pointer/mouse interaction on a header control from arming a pane drag.
+ * dockview's tab is draggable via two backends — native HTML5 (`dragstart`,
+ * blocked by `preventDefault` on pointerdown) and a pointer drag source (blocked
+ * by `stopPropagation` so the tab element never sees the event). The built-in
+ * close button does the same `preventDefault`; we add `stopPropagation` to also
+ * neutralise the pointer backend.
+ */
+function blockDrag(event: SyntheticEvent) {
+  event.stopPropagation();
+  event.preventDefault();
+}
+
+const DRAG_BLOCKERS = {
+  onPointerDown: blockDrag,
+  onMouseDown: blockDrag,
+} as const;
+
+interface MenuRect {
+  top: number;
+  left: number;
+  /** Width of the trigger, so the menu can size/align relative to it. */
+  triggerWidth: number;
+}
+
+/**
+ * Track the viewport rect of a trigger element while `open`, recomputing on
+ * open and on scroll/resize so a menu portaled to `document.body` (position:
+ * fixed) stays glued to its trigger. Returns null while closed.
+ */
+function useAnchorRect(
+  triggerRef: React.RefObject<HTMLElement | null>,
+  open: boolean,
+): MenuRect | null {
+  const [rect, setRect] = useState<MenuRect | null>(null);
+
+  const measure = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    setRect({ top: r.bottom, left: r.left, triggerWidth: r.width });
+  }, [triggerRef]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setRect(null);
+      return;
+    }
+    measure();
+    // Capture-phase scroll catches nested scroll containers (e.g. a pane body).
+    window.addEventListener('scroll', measure, true);
+    window.addEventListener('resize', measure);
+    return () => {
+      window.removeEventListener('scroll', measure, true);
+      window.removeEventListener('resize', measure);
+    };
+  }, [open, measure]);
+
+  return rect;
+}
+
+/**
+ * Close `open` when a pointer goes down outside both the trigger and the
+ * portaled menu. Both refs are checked because the menu lives in document.body,
+ * outside the trigger's DOM subtree.
+ */
+function useDismissOnOutside(
+  open: boolean,
+  setOpen: (value: boolean) => void,
+  triggerRef: React.RefObject<HTMLElement | null>,
+  menuRef: React.RefObject<HTMLElement | null>,
+) {
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (menuRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open, setOpen, triggerRef, menuRef]);
+}
+
+export interface TabPickerProps {
+  paneId: string;
+  /** Currently selected tab in this pane (null for a fresh/empty pane). */
+  activeTabId: WorkspaceTabId | null;
+  /** Compact prompt styling for an empty pane vs. the inline header trigger. */
+  variant: 'header' | 'empty';
+}
+
+/**
+ * Dropdown listing every workspace tab. Tabs already open in another pane are
+ * disabled to enforce the store's at-most-once rule; the tab hosted by this pane
+ * stays selectable so it reads as the current value. The menu is portaled to
+ * document.body so it paints above sibling panes.
+ */
+export function TabPicker({ paneId, activeTabId, variant }: TabPickerProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const setPaneTab = useWorkspaceStore((state) => state.setPaneTab);
+  const openTabIds = useOpenTabIds();
+
+  const rect = useAnchorRect(triggerRef, open);
+  useDismissOnOutside(open, setOpen, triggerRef, menuRef);
+
+  const activeTab = activeTabId ? getWorkspaceTab(activeTabId) : undefined;
+
+  const handleSelect = (tabId: WorkspaceTabId) => {
+    if (tabId !== activeTabId) {
+      setPaneTab(paneId, tabId);
+    }
+    setOpen(false);
+  };
+
+  const triggerClass =
+    variant === 'empty'
+      ? 'flex items-center gap-2 rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-3 py-2 text-sm font-medium text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface-2)] transition-colors'
+      : 'flex max-w-[12rem] items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-[color:var(--text-primary)] hover:bg-[color:var(--surface-2)] transition-colors';
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        {...DRAG_BLOCKERS}
+        className={triggerClass}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        title={variant === 'empty' ? 'Choose a tab for this pane' : 'Switch this pane’s view'}
+      >
+        {activeTab ? (
+          <>
+            <activeTab.icon size={15} className="shrink-0 text-[color:var(--text-muted)]" />
+            <span className="truncate">{activeTab.label}</span>
+          </>
+        ) : (
+          <span className="truncate text-[color:var(--text-secondary)]">Choose a tab…</span>
+        )}
+        <ChevronDown size={14} className="shrink-0 text-[color:var(--text-muted)]" />
+      </button>
+
+      {open &&
+        rect &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="listbox"
+            style={{ position: 'fixed', top: rect.top + 4, left: rect.left, zIndex: 1000 }}
+            className="max-h-80 w-56 overflow-y-auto rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] py-1 shadow-lg shadow-black/20"
+          >
+            {WORKSPACE_TABS.map((tab) => {
+              const isCurrent = tab.id === activeTabId;
+              // Disabled when open in a *different* pane (at-most-once).
+              const disabled = !isCurrent && openTabIds.includes(tab.id);
+              return (
+                <button
+                  type="button"
+                  key={tab.id}
+                  role="option"
+                  aria-selected={isCurrent}
+                  disabled={disabled}
+                  onClick={() => handleSelect(tab.id)}
+                  className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors ${
+                    disabled
+                      ? 'cursor-not-allowed text-[color:var(--text-muted)] opacity-50'
+                      : isCurrent
+                        ? 'bg-[color:var(--surface-accent)] text-[color:var(--text-primary)]'
+                        : 'text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]'
+                  }`}
+                >
+                  <tab.icon size={15} className="shrink-0" />
+                  <span className="flex-1 truncate">{tab.label}</span>
+                  {isCurrent && <Check size={14} className="shrink-0 text-[color:var(--text-primary)]" />}
+                  {disabled && (
+                    <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide">
+                      Open
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+interface SplitMenuProps {
+  paneId: string;
+}
+
+const SPLIT_OPTIONS: { direction: SplitDirection; label: string }[] = [
+  { direction: 'right', label: 'Split right' },
+  { direction: 'below', label: 'Split down' },
+  { direction: 'left', label: 'Split left' },
+  { direction: 'above', label: 'Split up' },
+];
+
+/**
+ * Split control: opens a new pane in the chosen direction hosting a tab that is
+ * not already open elsewhere (the store rejects duplicates). The menu is
+ * portaled to document.body so it paints above sibling panes; it is right-
+ * aligned under the trigger.
+ */
+function SplitMenu({ paneId }: SplitMenuProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const splitPane = useWorkspaceStore((state) => state.splitPane);
+  const openTabIds = useOpenTabIds();
+
+  // Tabs not yet open anywhere are eligible to seed a new pane.
+  const availableTabs = WORKSPACE_TABS.filter((tab) => !openTabIds.includes(tab.id));
+  const canSplit = availableTabs.length > 0;
+
+  const rect = useAnchorRect(triggerRef, open);
+  useDismissOnOutside(open, setOpen, triggerRef, menuRef);
+
+  const [direction, setDirection] = useState<SplitDirection>('right');
+
+  const handleSplit = (tabId: WorkspaceTabId) => {
+    splitPane(paneId, tabId, direction);
+    setOpen(false);
+  };
+
+  const MENU_WIDTH = 224; // w-56
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => canSplit && setOpen((value) => !value)}
+        {...DRAG_BLOCKERS}
+        disabled={!canSplit}
+        title={canSplit ? 'Split pane' : 'All tabs are already open'}
+        className={`rounded-md p-1.5 transition-colors ${
+          canSplit
+            ? 'text-[color:var(--text-primary)] hover:bg-[color:var(--surface-2)]'
+            : 'cursor-not-allowed text-[color:var(--text-muted)] opacity-40'
+        }`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <SplitSquareHorizontal size={16} />
+      </button>
+
+      {open &&
+        rect &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            style={{
+              position: 'fixed',
+              top: rect.top + 4,
+              // Right-align the menu under the trigger's right edge.
+              left: Math.max(8, rect.left + rect.triggerWidth - MENU_WIDTH),
+              zIndex: 1000,
+            }}
+            className="w-56 rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] py-1 shadow-lg shadow-black/20"
+          >
+            <div className="flex items-center gap-1 border-b border-[color:var(--border-subtle)] px-2 pb-1.5 pt-1">
+              {SPLIT_OPTIONS.map((option) => (
+                <button
+                  type="button"
+                  key={option.direction}
+                  onClick={() => setDirection(option.direction)}
+                  title={option.label}
+                  className={`flex flex-1 items-center justify-center rounded p-1.5 transition-colors ${
+                    direction === option.direction
+                      ? 'bg-[color:var(--surface-accent)] text-[color:var(--text-primary)]'
+                      : 'text-[color:var(--text-muted)] hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]'
+                  }`}
+                >
+                  {option.direction === 'right' || option.direction === 'left' ? (
+                    <SplitSquareHorizontal
+                      size={15}
+                      style={
+                        option.direction === 'left'
+                          ? ({ transform: 'scaleX(-1)' } as CSSProperties)
+                          : undefined
+                      }
+                    />
+                  ) : (
+                    <SplitSquareVertical
+                      size={15}
+                      style={
+                        option.direction === 'above'
+                          ? ({ transform: 'scaleY(-1)' } as CSSProperties)
+                          : undefined
+                      }
+                    />
+                  )}
+                </button>
+              ))}
+            </div>
+            <div className="max-h-64 overflow-y-auto py-1">
+              <p className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--text-muted)]">
+                Open in new pane
+              </p>
+              {availableTabs.map((tab) => (
+                <button
+                  type="button"
+                  key={tab.id}
+                  onClick={() => handleSplit(tab.id)}
+                  className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm text-[color:var(--text-secondary)] transition-colors hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]"
+                >
+                  <tab.icon size={15} className="shrink-0" />
+                  <span className="flex-1 truncate">{tab.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+/**
+ * Custom dockview tab, registered as `defaultTabComponent`. With
+ * `singleTabMode="fullwidth"` this fills the group's tab strip, so it doubles as
+ * the pane's header bar: dockview makes the tab element draggable, so dragging
+ * the empty areas of this bar repositions the pane natively (the host's
+ * `onWillShowOverlay` guard still blocks stacking, leaving only edge splits /
+ * repositioning). Interactive controls call {@link blockDrag} on pointer/mouse
+ * down so clicking them never starts a drag.
+ *
+ * dockview re-invokes this with fresh `params` whenever `updateParameters`
+ * runs, so reading `params.tabId` reflects tab switches without extra state.
+ */
+export function PaneHeaderTab(props: IDockviewPanelHeaderProps<WorkspacePaneParams>) {
+  const paneId = props.api.id;
+  const tabId = readTabId(props.params);
+  const closePane = useWorkspaceStore((state) => state.closePane);
+
+  return (
+    <div className="flex h-full w-full items-center justify-between gap-2 border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] px-2 text-[color:var(--text-primary)]">
+      <div className="flex min-w-0 items-center gap-1">
+        <TabPicker paneId={paneId} activeTabId={tabId} variant="header" />
+      </div>
+      <div className="flex shrink-0 items-center gap-0.5">
+        <SplitMenu paneId={paneId} />
+        <button
+          type="button"
+          onClick={() => closePane(paneId)}
+          {...DRAG_BLOCKERS}
+          title="Close pane"
+          className="rounded-md p-1.5 text-[color:var(--text-primary)] transition-colors hover:bg-[color:var(--surface-2)]"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/sentinel/src/components/workspace/TerminalTab.tsx
+++ b/apps/frontend/sentinel/src/components/workspace/TerminalTab.tsx
@@ -1,0 +1,117 @@
+import { Loader2, Terminal } from 'lucide-react';
+
+import { useInstanceName } from '../../lib/workspace-context';
+import { useActiveSessionId } from '../../store/active-session-store';
+import { useSessionRuntimeStream } from '../../hooks/useSessionRuntimeStream';
+import { getTerminalLabel, summarizeCommand } from '../../lib/terminalIdentity';
+import { TerminalPreview } from '../session/TerminalPreview';
+
+/**
+ * Standalone TERMINAL workspace tab.
+ *
+ * Hosts multiple terminals for the workspace-wide active session: a strip of
+ * terminal pills (label + busy badge + focused selection) when more than one is
+ * open, and a single {@link TerminalPreview} for the focused terminal. The
+ * terminal list, focus, and create/close lifecycle all come from the shared
+ * {@link useSessionRuntimeStream} hook — the same socket SessionsPage uses — so
+ * opening this tab alongside the chat view yields ONE WebSocket per session.
+ *
+ * `desktopViewActive: false` here: this tab never drives the live-view poll or
+ * runtime-status fetch (those belong to the Desktop tab), so we don't spin up
+ * polling we won't use.
+ */
+export function TerminalTab() {
+  const instanceName = useInstanceName() ?? null;
+  const activeSessionId = useActiveSessionId();
+
+  const {
+    activeTerminals,
+    focusedTerminalId,
+    setFocusedTerminalId,
+  } = useSessionRuntimeStream(instanceName, activeSessionId, {
+    desktopViewActive: false,
+  });
+
+  // Effective focus falls back to the first terminal when nothing is explicitly
+  // selected — this is the auto-focus parity: the first terminal to open is
+  // previewed without a manual click, matching SessionsPage's terminals view.
+  const effectiveTerminalId = focusedTerminalId ?? activeTerminals[0]?.id ?? null;
+
+  // Empty state: no session selected anywhere in the workspace.
+  if (!activeSessionId) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center text-[color:var(--text-muted)] opacity-60">
+        <div className="rounded-2xl bg-[color:var(--surface-2)] p-3">
+          <Terminal size={24} strokeWidth={1} />
+        </div>
+        <p className="text-[10px] font-medium uppercase tracking-widest">No session selected</p>
+        <p className="max-w-[220px] text-[10px] leading-relaxed">
+          Select a session to view its terminals here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col bg-[color:var(--surface-0)]">
+      {/* Terminal strip: only when more than one terminal is open. */}
+      {activeTerminals.length > 1 ? (
+        <div className="flex items-center gap-1 overflow-x-auto custom-scrollbar border-b border-[color:var(--border-subtle)] px-3 py-2">
+          {activeTerminals.map((terminal) => {
+            // Label is derived from terminal_id: '0' → "main", auto/bg ids →
+            // first command summary, otherwise the agent's chosen name verbatim.
+            const display = getTerminalLabel(terminal.id, terminal.lastCommand ?? terminal.label);
+            const isFocused = effectiveTerminalId === terminal.id;
+            const tooltip = terminal.lastCommand
+              ? `${display} — last: ${summarizeCommand(terminal.lastCommand)}`
+              : display;
+            return (
+              <button
+                key={terminal.id}
+                type="button"
+                onClick={() => setFocusedTerminalId(terminal.id)}
+                className={`inline-flex h-6 shrink-0 items-center gap-1 rounded-md px-2 text-[10px] font-medium transition-colors ${
+                  isFocused
+                    ? 'bg-sky-500/20 text-sky-300'
+                    : 'text-[color:var(--text-muted)] hover:bg-[color:var(--surface-2)]'
+                }`}
+                title={tooltip}
+              >
+                <span className="max-w-[120px] truncate">{display}</span>
+                {terminal.busy ? <Loader2 size={9} className="animate-spin" /> : null}
+              </button>
+            );
+          })}
+          <span className="ml-auto shrink-0 rounded-full bg-[color:var(--surface-2)] px-2 py-0.5 text-[10px] font-bold tabular-nums text-[color:var(--text-muted)]">
+            {activeTerminals.length}
+          </span>
+        </div>
+      ) : null}
+
+      {/* Focused terminal preview, or empty state when none are open. */}
+      <div className="min-h-0 flex-1">
+        {effectiveTerminalId ? (
+          // Keyed on the (session, terminal) pair so React tears down and
+          // re-creates the xterm + WS when the user switches terminals; sharing
+          // state across terminals would mix scrollback.
+          <TerminalPreview
+            key={`${activeSessionId}:${effectiveTerminalId}`}
+            sessionId={activeSessionId}
+            terminalId={effectiveTerminalId}
+            instanceName={instanceName ?? ''}
+          />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center text-[color:var(--text-muted)] opacity-60">
+            <div className="rounded-2xl bg-[color:var(--surface-2)] p-3">
+              <Terminal size={24} strokeWidth={1} />
+            </div>
+            <p className="text-[10px] font-medium uppercase tracking-widest">No terminals open</p>
+            <p className="max-w-[220px] text-[10px] leading-relaxed">
+              The agent will open one here when it runs a shell command.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/sentinel/src/components/workspace/Workspace.tsx
+++ b/apps/frontend/sentinel/src/components/workspace/Workspace.tsx
@@ -5,6 +5,7 @@ import {
   themeLight,
   type DockviewApi,
   type DockviewReadyEvent,
+  type DockviewWillShowOverlayLocationEvent,
 } from 'dockview-react';
 import 'dockview-react/dist/styles/dockview.css';
 
@@ -18,9 +19,60 @@ import {
 } from '../../store/workspace-store';
 import { WORKSPACE_TABS } from '../../lib/workspace-tabs';
 import { WorkspacePane, WorkspaceInstanceContext } from './WorkspacePane';
+import { PaneHeaderTab } from './PaneHeaderTab';
 
 /** dockview-react requires the single content component registered by id. */
 const DOCKVIEW_COMPONENTS = { [WORKSPACE_PANEL_COMPONENT]: WorkspacePane };
+
+/**
+ * The custom dockview tab doubling as the pane header. Registered as
+ * `defaultTabComponent` and rendered full-width (`singleTabMode="fullwidth"`),
+ * so the whole header bar is dockview's draggable tab element — dragging its
+ * empty areas repositions the pane. Per-tab renderers keyed by id.
+ */
+const DOCKVIEW_TAB_COMPONENTS = { [WORKSPACE_PANEL_COMPONENT]: PaneHeaderTab };
+
+/**
+ * Scoped CSS for the workspace host. One-view-per-pane means dockview's tab strip
+ * holds exactly one full-width tab, which we use as the pane header
+ * ({@link PaneHeaderTab}). We size that strip to the header height and strip the
+ * default chrome (divider/border/min-width) so only our themed header shows.
+ * Injected here rather than the global stylesheet to keep the override
+ * co-located with the host; `!important` overrides the theme cascade.
+ */
+const DOCKVIEW_TAB_STRIP_CSS = `
+.dockview-pane-header .dv-tabs-and-actions-container {
+  height: 40px !important;
+}
+.dockview-pane-header .dv-tab {
+  padding: 0 !important;
+  border: none !important;
+  min-width: 0 !important;
+}
+.dockview-pane-header .dv-tab::before {
+  display: none !important;
+}
+.dockview-pane-header {
+  --dv-group-view-background-color: var(--app-bg);
+}
+`;
+
+/**
+ * Block any drop that would stack panels into a tab group, preserving the
+ * one-view-per-pane invariant. Edge drops (top/bottom/left/right onto content
+ * or the root edge) reposition / split and are allowed; drops onto a tab strip,
+ * the header free space, or the centre of a pane would stack, so they are
+ * prevented.
+ */
+function blockStackingDrops(event: DockviewWillShowOverlayLocationEvent) {
+  if (
+    event.kind === 'tab' ||
+    event.kind === 'header_space' ||
+    event.position === 'center'
+  ) {
+    event.preventDefault();
+  }
+}
 
 export interface WorkspaceProps {
   /**
@@ -52,6 +104,12 @@ export function Workspace({ instanceName, className = '' }: WorkspaceProps) {
   // Track when the api is bound so the empty-state CTA can open the first tab.
   const apiRef = useRef<DockviewApi | null>(null);
   const [apiReady, setApiReady] = useState(false);
+  // Reactive count of live panes. Driven by dockview's onDidLayoutChange (plus a
+  // seed in onReady) so the empty-state overlay reliably hides whenever a pane
+  // exists — independent of when panel params land or whether the open-tab
+  // selector happens to change. Reading apiRef.current?.panels.length during
+  // render would not re-render on its own (a ref is not reactive).
+  const [paneCount, setPaneCount] = useState(0);
   const [addOpen, setAddOpen] = useState(false);
   const addRef = useRef<HTMLDivElement>(null);
 
@@ -59,7 +117,14 @@ export function Workspace({ instanceName, className = '' }: WorkspaceProps) {
     const store = useWorkspaceStore.getState();
     apiRef.current = event.api;
     // bindApi seeds state immediately and subscribes to layout changes.
-    const dispose = store.bindApi(event.api);
+    const disposeBind = store.bindApi(event.api);
+    // Prevent stacking drops so every group keeps exactly one panel.
+    const overlay = event.api.onWillShowOverlay(blockStackingDrops);
+    // Keep paneCount in sync with the live layout so the overlay reflects pane
+    // presence. onDidLayoutChange fires (asynchronously) on every add/remove.
+    const layout = event.api.onDidLayoutChange(() => {
+      setPaneCount(event.api.panels.length);
+    });
     const saved = store.layout;
     if (saved) {
       try {
@@ -71,10 +136,16 @@ export function Workspace({ instanceName, className = '' }: WorkspaceProps) {
       }
     }
     setApiReady(true);
-    disposeRef.current = dispose;
+    // Seed the count after any restore so the overlay starts in the right state.
+    setPaneCount(event.api.panels.length);
+    disposeRef.current = () => {
+      layout.dispose();
+      overlay.dispose();
+      disposeBind();
+    };
   }, []);
 
-  // Hold the bindApi disposer so it runs on unmount.
+  // Hold the combined disposer so it runs on unmount.
   const disposeRef = useRef<(() => void) | null>(null);
   useEffect(() => {
     return () => {
@@ -89,8 +160,7 @@ export function Workspace({ instanceName, className = '' }: WorkspaceProps) {
     [theme],
   );
 
-  const panelCount = apiReady ? apiRef.current?.panels.length ?? 0 : 0;
-  const hasPanels = panelCount > 0;
+  const hasPanels = paneCount > 0;
 
   const availableTabs = useMemo(
     () => WORKSPACE_TABS.filter((tab) => !openTabIds.includes(tab.id)),
@@ -114,17 +184,22 @@ export function Workspace({ instanceName, className = '' }: WorkspaceProps) {
         className={`relative flex h-full w-full flex-col overflow-hidden bg-[color:var(--app-bg)] ${className}`}
       >
         <div className="relative min-h-0 flex-1">
+          <style>{DOCKVIEW_TAB_STRIP_CSS}</style>
           <DockviewReact
             components={DOCKVIEW_COMPONENTS}
+            tabComponents={DOCKVIEW_TAB_COMPONENTS}
+            defaultTabComponent={PaneHeaderTab}
             onReady={onReady}
             theme={dockviewTheme}
-            className="h-full w-full"
+            singleTabMode="fullwidth"
+            disableFloatingGroups
+            className="dockview-pane-header h-full w-full"
           />
 
           {/* Empty-state overlay: no panes yet -> invite the user to open a tab.
               dockview renders nothing meaningful until the first panel exists. */}
           {apiReady && !hasPanels && (
-            <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-5 p-8 text-center">
+            <div className="absolute inset-0 z-[1000] flex flex-col items-center justify-center gap-5 bg-[color:var(--app-bg)] p-8 text-center">
               <div className="pointer-events-auto flex flex-col items-center gap-4">
                 <div>
                   <p className="text-sm font-medium text-[color:var(--text-primary)]">
@@ -138,15 +213,17 @@ export function Workspace({ instanceName, className = '' }: WorkspaceProps) {
                   <button
                     type="button"
                     onClick={() => setAddOpen((value) => !value)}
-                    className="flex items-center gap-2 rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 py-2 text-sm font-medium text-[color:var(--text-primary)] transition-colors hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface-2)]"
+                    aria-haspopup="listbox"
+                    aria-expanded={addOpen}
+                    className="flex items-center gap-2 rounded-md bg-[color:var(--accent-solid)] px-4 py-2 text-sm font-medium text-[color:var(--app-bg)] shadow-sm transition-opacity hover:opacity-90"
                   >
-                    <Plus size={16} className="text-[color:var(--text-muted)]" />
+                    <Plus size={16} />
                     Open a tab
                   </button>
                   {addOpen && (
                     <div
                       role="listbox"
-                      className="absolute left-1/2 top-[calc(100%+6px)] z-50 max-h-80 w-56 -translate-x-1/2 overflow-y-auto rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] py-1 text-left shadow-lg shadow-black/20"
+                      className="absolute left-1/2 top-[calc(100%+6px)] z-50 max-h-80 w-56 -translate-x-1/2 overflow-y-auto rounded-md border border-[color:var(--border-strong)] bg-[color:var(--surface-1)] py-1 text-left shadow-lg shadow-black/30"
                     >
                       {availableTabs.map((tab) => (
                         <button
@@ -158,7 +235,7 @@ export function Workspace({ instanceName, className = '' }: WorkspaceProps) {
                             openTab(tab.id);
                             setAddOpen(false);
                           }}
-                          className="flex w-full items-center gap-2.5 px-3 py-1.5 text-sm text-[color:var(--text-secondary)] transition-colors hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]"
+                          className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm text-[color:var(--text-secondary)] transition-colors hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)]"
                         >
                           <tab.icon size={15} className="shrink-0" />
                           <span className="flex-1 truncate">{tab.label}</span>

--- a/apps/frontend/sentinel/src/components/workspace/Workspace.tsx
+++ b/apps/frontend/sentinel/src/components/workspace/Workspace.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  DockviewReact,
+  themeDark,
+  themeLight,
+  type DockviewApi,
+  type DockviewReadyEvent,
+} from 'dockview-react';
+import 'dockview-react/dist/styles/dockview.css';
+
+import { Plus } from 'lucide-react';
+
+import { useThemeStore } from '../../store/theme-store';
+import {
+  WORKSPACE_PANEL_COMPONENT,
+  useWorkspaceStore,
+  useOpenTabIds,
+} from '../../store/workspace-store';
+import { WORKSPACE_TABS } from '../../lib/workspace-tabs';
+import { WorkspacePane, WorkspaceInstanceContext } from './WorkspacePane';
+
+/** dockview-react requires the single content component registered by id. */
+const DOCKVIEW_COMPONENTS = { [WORKSPACE_PANEL_COMPONENT]: WorkspacePane };
+
+export interface WorkspaceProps {
+  /**
+   * Instance the whole workspace is scoped to. Supplied to every pane through
+   * {@link WorkspaceInstanceContext} so pages can resolve their instance via
+   * `useInstanceName()` even though panes are not the active route.
+   */
+  instanceName: string | undefined;
+  /** Optional extra classes for the outer fill container. */
+  className?: string;
+}
+
+/**
+ * Tiling workspace host.
+ *
+ * Wires dockview to the workspace store: on ready it binds the live
+ * `DockviewApi` (the store subscribes to layout changes and persists
+ * `toJSON()`), then restores any saved layout. Splitting / closing / resizing /
+ * drag-and-drop are all owned by dockview; the store mirrors the result.
+ *
+ * The dockview theme tracks the app's light/dark mode so the chrome (tab strips,
+ * sashes, drop overlays) matches the surrounding UI.
+ */
+export function Workspace({ instanceName, className = '' }: WorkspaceProps) {
+  const theme = useThemeStore((state) => state.theme);
+  const openTab = useWorkspaceStore((state) => state.openTab);
+  const openTabIds = useOpenTabIds();
+
+  // Track when the api is bound so the empty-state CTA can open the first tab.
+  const apiRef = useRef<DockviewApi | null>(null);
+  const [apiReady, setApiReady] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
+  const addRef = useRef<HTMLDivElement>(null);
+
+  const onReady = useCallback((event: DockviewReadyEvent) => {
+    const store = useWorkspaceStore.getState();
+    apiRef.current = event.api;
+    // bindApi seeds state immediately and subscribes to layout changes.
+    const dispose = store.bindApi(event.api);
+    const saved = store.layout;
+    if (saved) {
+      try {
+        event.api.fromJSON(saved);
+      } catch {
+        // A corrupt / incompatible persisted layout should not wedge the UI:
+        // drop it and start from an empty workspace.
+        store.resetWorkspace();
+      }
+    }
+    setApiReady(true);
+    disposeRef.current = dispose;
+  }, []);
+
+  // Hold the bindApi disposer so it runs on unmount.
+  const disposeRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    return () => {
+      disposeRef.current?.();
+      disposeRef.current = null;
+      apiRef.current = null;
+    };
+  }, []);
+
+  const dockviewTheme = useMemo(
+    () => (theme === 'dark' ? themeDark : themeLight),
+    [theme],
+  );
+
+  const panelCount = apiReady ? apiRef.current?.panels.length ?? 0 : 0;
+  const hasPanels = panelCount > 0;
+
+  const availableTabs = useMemo(
+    () => WORKSPACE_TABS.filter((tab) => !openTabIds.includes(tab.id)),
+    [openTabIds],
+  );
+
+  useEffect(() => {
+    if (!addOpen) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (addRef.current && !addRef.current.contains(event.target as Node)) {
+        setAddOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [addOpen]);
+
+  return (
+    <WorkspaceInstanceContext.Provider value={instanceName}>
+      <div
+        className={`relative flex h-full w-full flex-col overflow-hidden bg-[color:var(--app-bg)] ${className}`}
+      >
+        <div className="relative min-h-0 flex-1">
+          <DockviewReact
+            components={DOCKVIEW_COMPONENTS}
+            onReady={onReady}
+            theme={dockviewTheme}
+            className="h-full w-full"
+          />
+
+          {/* Empty-state overlay: no panes yet -> invite the user to open a tab.
+              dockview renders nothing meaningful until the first panel exists. */}
+          {apiReady && !hasPanels && (
+            <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-5 p-8 text-center">
+              <div className="pointer-events-auto flex flex-col items-center gap-4">
+                <div>
+                  <p className="text-sm font-medium text-[color:var(--text-primary)]">
+                    Your workspace is empty
+                  </p>
+                  <p className="mt-1 text-xs text-[color:var(--text-secondary)]">
+                    Open a tab to start. Split panes to view several at once.
+                  </p>
+                </div>
+                <div ref={addRef} className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setAddOpen((value) => !value)}
+                    className="flex items-center gap-2 rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 py-2 text-sm font-medium text-[color:var(--text-primary)] transition-colors hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface-2)]"
+                  >
+                    <Plus size={16} className="text-[color:var(--text-muted)]" />
+                    Open a tab
+                  </button>
+                  {addOpen && (
+                    <div
+                      role="listbox"
+                      className="absolute left-1/2 top-[calc(100%+6px)] z-50 max-h-80 w-56 -translate-x-1/2 overflow-y-auto rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] py-1 text-left shadow-lg shadow-black/20"
+                    >
+                      {availableTabs.map((tab) => (
+                        <button
+                          type="button"
+                          key={tab.id}
+                          role="option"
+                          aria-selected={false}
+                          onClick={() => {
+                            openTab(tab.id);
+                            setAddOpen(false);
+                          }}
+                          className="flex w-full items-center gap-2.5 px-3 py-1.5 text-sm text-[color:var(--text-secondary)] transition-colors hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]"
+                        >
+                          <tab.icon size={15} className="shrink-0" />
+                          <span className="flex-1 truncate">{tab.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </WorkspaceInstanceContext.Provider>
+  );
+}
+
+/**
+ * Re-exported so integrators can wire a "reset layout" affordance without
+ * reaching into the store directly.
+ */
+export function useResetWorkspace() {
+  return useWorkspaceStore((state) => state.resetWorkspace);
+}

--- a/apps/frontend/sentinel/src/components/workspace/WorkspacePane.tsx
+++ b/apps/frontend/sentinel/src/components/workspace/WorkspacePane.tsx
@@ -18,8 +18,22 @@ import { TabPicker } from './PaneHeaderTab';
  */
 export const WorkspaceInstanceContext = createContext<string | undefined>(undefined);
 
+/**
+ * Carries this pane's dockview id (`props.api.id`) down into the content
+ * subtree. The pane's tab and its content live in separate React trees, so the
+ * page's {@link AppShell} cannot derive the id on its own — it reads this
+ * context to register its header actions under the right pane in the
+ * pane-actions store. Undefined outside a pane (the standalone route case).
+ */
+export const PaneIdContext = createContext<string | undefined>(undefined);
+
 function useHostInstanceName(): string | undefined {
   return useContext(WorkspaceInstanceContext);
+}
+
+/** Read the hosting pane's id from the surrounding {@link PaneIdContext}. */
+export function usePaneId(): string | undefined {
+  return useContext(PaneIdContext);
 }
 
 /** Read the current `tabId` off the panel params, validated against the registry. */
@@ -53,9 +67,11 @@ export function WorkspacePane(props: IDockviewPanelProps<WorkspacePaneParams>) {
     <div className="flex h-full w-full flex-col overflow-hidden bg-[color:var(--surface-0)] text-[color:var(--text-primary)]">
       <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden bg-[color:var(--app-bg)]">
         {TabComponent ? (
-          <WorkspaceProvider instanceName={instanceName} workspaceMode>
-            <TabComponent />
-          </WorkspaceProvider>
+          <PaneIdContext.Provider value={paneId}>
+            <WorkspaceProvider instanceName={instanceName} workspaceMode>
+              <TabComponent />
+            </WorkspaceProvider>
+          </PaneIdContext.Provider>
         ) : (
           <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-8 text-center">
             <p className="text-sm text-[color:var(--text-secondary)]">

--- a/apps/frontend/sentinel/src/components/workspace/WorkspacePane.tsx
+++ b/apps/frontend/sentinel/src/components/workspace/WorkspacePane.tsx
@@ -1,0 +1,354 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
+import type { IDockviewPanelProps } from 'dockview-react';
+import {
+  ChevronDown,
+  Check,
+  SplitSquareHorizontal,
+  SplitSquareVertical,
+  X,
+} from 'lucide-react';
+
+import { WorkspaceProvider } from '../../lib/workspace-context';
+import {
+  WORKSPACE_TABS,
+  getWorkspaceTab,
+  isWorkspaceTabId,
+  type WorkspaceTabId,
+} from '../../lib/workspace-tabs';
+import {
+  useWorkspaceStore,
+  useOpenTabIds,
+  type WorkspacePaneParams,
+  type SplitDirection,
+} from '../../store/workspace-store';
+
+/**
+ * Carries the active instance name from the {@link Workspace} host down into the
+ * dockview-rendered panes. Panes are mounted via React portals, so ordinary
+ * context still propagates, but the route-derived `:instanceName` is not
+ * available inside a pane — this context supplies it explicitly.
+ */
+export const WorkspaceInstanceContext = createContext<string | undefined>(undefined);
+
+function useHostInstanceName(): string | undefined {
+  return useContext(WorkspaceInstanceContext);
+}
+
+/** Read the current `tabId` off the panel params, validated against the registry. */
+function readTabId(params: Partial<WorkspacePaneParams> | undefined): WorkspaceTabId | null {
+  const raw = params?.tabId;
+  if (typeof raw === 'string' && isWorkspaceTabId(raw)) {
+    return raw;
+  }
+  return null;
+}
+
+interface TabPickerProps {
+  paneId: string;
+  /** Currently selected tab in this pane (null for a fresh/empty pane). */
+  activeTabId: WorkspaceTabId | null;
+  /** Compact prompt styling for an empty pane vs. the inline header trigger. */
+  variant: 'header' | 'empty';
+}
+
+/**
+ * Dropdown listing every workspace tab. Tabs already open in another pane are
+ * disabled to enforce the store's at-most-once rule; the tab hosted by this pane
+ * stays selectable so it reads as the current value.
+ */
+function TabPicker({ paneId, activeTabId, variant }: TabPickerProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const setPaneTab = useWorkspaceStore((state) => state.setPaneTab);
+  const openTabIds = useOpenTabIds();
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const activeTab = activeTabId ? getWorkspaceTab(activeTabId) : undefined;
+
+  const handleSelect = (tabId: WorkspaceTabId) => {
+    if (tabId !== activeTabId) {
+      setPaneTab(paneId, tabId);
+    }
+    setOpen(false);
+  };
+
+  const triggerClass =
+    variant === 'empty'
+      ? 'flex items-center gap-2 rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-3 py-2 text-sm font-medium text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface-2)] transition-colors'
+      : 'flex max-w-[12rem] items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-[color:var(--text-primary)] hover:bg-[color:var(--surface-2)] transition-colors';
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className={triggerClass}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        title={variant === 'empty' ? 'Choose a tab for this pane' : 'Switch tab'}
+      >
+        {activeTab ? (
+          <>
+            <activeTab.icon size={15} className="shrink-0 text-[color:var(--text-muted)]" />
+            <span className="truncate">{activeTab.label}</span>
+          </>
+        ) : (
+          <span className="truncate text-[color:var(--text-secondary)]">Choose a tab…</span>
+        )}
+        <ChevronDown size={14} className="shrink-0 text-[color:var(--text-muted)]" />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          className="absolute left-0 top-[calc(100%+4px)] z-50 max-h-80 w-56 overflow-y-auto rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] py-1 shadow-lg shadow-black/20"
+        >
+          {WORKSPACE_TABS.map((tab) => {
+            const isCurrent = tab.id === activeTabId;
+            // Disabled when open in a *different* pane (at-most-once).
+            const disabled = !isCurrent && openTabIds.includes(tab.id);
+            return (
+              <button
+                type="button"
+                key={tab.id}
+                role="option"
+                aria-selected={isCurrent}
+                disabled={disabled}
+                onClick={() => handleSelect(tab.id)}
+                className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors ${
+                  disabled
+                    ? 'cursor-not-allowed text-[color:var(--text-muted)] opacity-50'
+                    : isCurrent
+                      ? 'bg-[color:var(--surface-accent)] text-[color:var(--text-primary)]'
+                      : 'text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]'
+                }`}
+              >
+                <tab.icon size={15} className="shrink-0" />
+                <span className="flex-1 truncate">{tab.label}</span>
+                {isCurrent && <Check size={14} className="shrink-0 text-[color:var(--text-primary)]" />}
+                {disabled && (
+                  <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide">
+                    Open
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SplitMenuProps {
+  paneId: string;
+}
+
+const SPLIT_OPTIONS: { direction: SplitDirection; label: string }[] = [
+  { direction: 'right', label: 'Split right' },
+  { direction: 'below', label: 'Split down' },
+  { direction: 'left', label: 'Split left' },
+  { direction: 'above', label: 'Split up' },
+];
+
+/**
+ * Split control: opens a new pane in the chosen direction hosting a tab that is
+ * not already open elsewhere (the store rejects duplicates). The icon hints
+ * horizontal vs. vertical based on the most-common right/down splits.
+ */
+function SplitMenu({ paneId }: SplitMenuProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const splitPane = useWorkspaceStore((state) => state.splitPane);
+  const openTabIds = useOpenTabIds();
+
+  // Tabs not yet open anywhere are eligible to seed a new pane.
+  const availableTabs = WORKSPACE_TABS.filter((tab) => !openTabIds.includes(tab.id));
+  const canSplit = availableTabs.length > 0;
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const [direction, setDirection] = useState<SplitDirection>('right');
+
+  const handleSplit = (tabId: WorkspaceTabId) => {
+    splitPane(paneId, tabId, direction);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => canSplit && setOpen((value) => !value)}
+        disabled={!canSplit}
+        title={canSplit ? 'Split pane' : 'All tabs are already open'}
+        className={`rounded-md p-1.5 transition-colors ${
+          canSplit
+            ? 'text-[color:var(--text-muted)] hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)]'
+            : 'cursor-not-allowed text-[color:var(--text-muted)] opacity-40'
+        }`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <SplitSquareHorizontal size={16} />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-[calc(100%+4px)] z-50 w-56 rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] py-1 shadow-lg shadow-black/20"
+        >
+          <div className="flex items-center gap-1 border-b border-[color:var(--border-subtle)] px-2 pb-1.5 pt-1">
+            {SPLIT_OPTIONS.map((option) => (
+              <button
+                type="button"
+                key={option.direction}
+                onClick={() => setDirection(option.direction)}
+                title={option.label}
+                className={`flex flex-1 items-center justify-center rounded p-1.5 transition-colors ${
+                  direction === option.direction
+                    ? 'bg-[color:var(--surface-accent)] text-[color:var(--text-primary)]'
+                    : 'text-[color:var(--text-muted)] hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]'
+                }`}
+              >
+                {option.direction === 'right' || option.direction === 'left' ? (
+                  <SplitSquareHorizontal
+                    size={15}
+                    style={
+                      option.direction === 'left'
+                        ? ({ transform: 'scaleX(-1)' } as CSSProperties)
+                        : undefined
+                    }
+                  />
+                ) : (
+                  <SplitSquareVertical
+                    size={15}
+                    style={
+                      option.direction === 'above'
+                        ? ({ transform: 'scaleY(-1)' } as CSSProperties)
+                        : undefined
+                    }
+                  />
+                )}
+              </button>
+            ))}
+          </div>
+          <div className="max-h-64 overflow-y-auto py-1">
+            <p className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--text-muted)]">
+              Open in new pane
+            </p>
+            {availableTabs.map((tab) => (
+              <button
+                type="button"
+                key={tab.id}
+                onClick={() => handleSplit(tab.id)}
+                className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm text-[color:var(--text-secondary)] transition-colors hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]"
+              >
+                <tab.icon size={15} className="shrink-0" />
+                <span className="flex-1 truncate">{tab.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Renderer for a single dockview panel. dockview re-invokes this with fresh
+ * `props.params` whenever `updateParameters` runs, so reading `props.params.tabId`
+ * reflects tab switches without extra state.
+ *
+ * Layout: a fixed header bar (tab picker + split + close) above a scrollable body
+ * that hosts the selected page wrapped in {@link WorkspaceProvider}. An empty pane
+ * shows a centered picker prompting the user to pick a tab.
+ */
+export function WorkspacePane(props: IDockviewPanelProps<WorkspacePaneParams>) {
+  const paneId = props.api.id;
+  const tabId = readTabId(props.params);
+  const instanceName = useHostInstanceName();
+
+  const closePane = useWorkspaceStore((state) => state.closePane);
+
+  const tab = tabId ? getWorkspaceTab(tabId) : undefined;
+  const TabComponent = tab?.component;
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden bg-[color:var(--surface-0)] text-[color:var(--text-primary)]">
+      {/* Header bar */}
+      <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] px-2">
+        <div className="flex min-w-0 items-center gap-1">
+          <TabPicker paneId={paneId} activeTabId={tabId} variant="header" />
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <SplitMenu paneId={paneId} />
+          <button
+            type="button"
+            onClick={() => closePane(paneId)}
+            title="Close pane"
+            className="rounded-md p-1.5 text-[color:var(--text-muted)] transition-colors hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)]"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden bg-[color:var(--app-bg)]">
+        {TabComponent ? (
+          <WorkspaceProvider instanceName={instanceName} workspaceMode>
+            <TabComponent />
+          </WorkspaceProvider>
+        ) : (
+          <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-8 text-center">
+            <p className="text-sm text-[color:var(--text-secondary)]">
+              This pane is empty. Choose a tab to display here.
+            </p>
+            <TabPicker paneId={paneId} activeTabId={null} variant="empty" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/sentinel/src/components/workspace/WorkspacePane.tsx
+++ b/apps/frontend/sentinel/src/components/workspace/WorkspacePane.tsx
@@ -1,33 +1,14 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-} from 'react';
+import { createContext, useContext } from 'react';
 import type { IDockviewPanelProps } from 'dockview-react';
-import {
-  ChevronDown,
-  Check,
-  SplitSquareHorizontal,
-  SplitSquareVertical,
-  X,
-} from 'lucide-react';
 
 import { WorkspaceProvider } from '../../lib/workspace-context';
 import {
-  WORKSPACE_TABS,
   getWorkspaceTab,
   isWorkspaceTabId,
   type WorkspaceTabId,
 } from '../../lib/workspace-tabs';
-import {
-  useWorkspaceStore,
-  useOpenTabIds,
-  type WorkspacePaneParams,
-  type SplitDirection,
-} from '../../store/workspace-store';
+import type { WorkspacePaneParams } from '../../store/workspace-store';
+import { TabPicker } from './PaneHeaderTab';
 
 /**
  * Carries the active instance name from the {@link Workspace} host down into the
@@ -50,291 +31,26 @@ function readTabId(params: Partial<WorkspacePaneParams> | undefined): WorkspaceT
   return null;
 }
 
-interface TabPickerProps {
-  paneId: string;
-  /** Currently selected tab in this pane (null for a fresh/empty pane). */
-  activeTabId: WorkspaceTabId | null;
-  /** Compact prompt styling for an empty pane vs. the inline header trigger. */
-  variant: 'header' | 'empty';
-}
-
 /**
- * Dropdown listing every workspace tab. Tabs already open in another pane are
- * disabled to enforce the store's at-most-once rule; the tab hosted by this pane
- * stays selectable so it reads as the current value.
- */
-function TabPicker({ paneId, activeTabId, variant }: TabPickerProps) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const setPaneTab = useWorkspaceStore((state) => state.setPaneTab);
-  const openTabIds = useOpenTabIds();
-
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false);
-    };
-    document.addEventListener('mousedown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
-    };
-  }, [open]);
-
-  const activeTab = activeTabId ? getWorkspaceTab(activeTabId) : undefined;
-
-  const handleSelect = (tabId: WorkspaceTabId) => {
-    if (tabId !== activeTabId) {
-      setPaneTab(paneId, tabId);
-    }
-    setOpen(false);
-  };
-
-  const triggerClass =
-    variant === 'empty'
-      ? 'flex items-center gap-2 rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-3 py-2 text-sm font-medium text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface-2)] transition-colors'
-      : 'flex max-w-[12rem] items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-[color:var(--text-primary)] hover:bg-[color:var(--surface-2)] transition-colors';
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen((value) => !value)}
-        className={triggerClass}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        title={variant === 'empty' ? 'Choose a tab for this pane' : 'Switch tab'}
-      >
-        {activeTab ? (
-          <>
-            <activeTab.icon size={15} className="shrink-0 text-[color:var(--text-muted)]" />
-            <span className="truncate">{activeTab.label}</span>
-          </>
-        ) : (
-          <span className="truncate text-[color:var(--text-secondary)]">Choose a tab…</span>
-        )}
-        <ChevronDown size={14} className="shrink-0 text-[color:var(--text-muted)]" />
-      </button>
-
-      {open && (
-        <div
-          role="listbox"
-          className="absolute left-0 top-[calc(100%+4px)] z-50 max-h-80 w-56 overflow-y-auto rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] py-1 shadow-lg shadow-black/20"
-        >
-          {WORKSPACE_TABS.map((tab) => {
-            const isCurrent = tab.id === activeTabId;
-            // Disabled when open in a *different* pane (at-most-once).
-            const disabled = !isCurrent && openTabIds.includes(tab.id);
-            return (
-              <button
-                type="button"
-                key={tab.id}
-                role="option"
-                aria-selected={isCurrent}
-                disabled={disabled}
-                onClick={() => handleSelect(tab.id)}
-                className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm transition-colors ${
-                  disabled
-                    ? 'cursor-not-allowed text-[color:var(--text-muted)] opacity-50'
-                    : isCurrent
-                      ? 'bg-[color:var(--surface-accent)] text-[color:var(--text-primary)]'
-                      : 'text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]'
-                }`}
-              >
-                <tab.icon size={15} className="shrink-0" />
-                <span className="flex-1 truncate">{tab.label}</span>
-                {isCurrent && <Check size={14} className="shrink-0 text-[color:var(--text-primary)]" />}
-                {disabled && (
-                  <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide">
-                    Open
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
-interface SplitMenuProps {
-  paneId: string;
-}
-
-const SPLIT_OPTIONS: { direction: SplitDirection; label: string }[] = [
-  { direction: 'right', label: 'Split right' },
-  { direction: 'below', label: 'Split down' },
-  { direction: 'left', label: 'Split left' },
-  { direction: 'above', label: 'Split up' },
-];
-
-/**
- * Split control: opens a new pane in the chosen direction hosting a tab that is
- * not already open elsewhere (the store rejects duplicates). The icon hints
- * horizontal vs. vertical based on the most-common right/down splits.
- */
-function SplitMenu({ paneId }: SplitMenuProps) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const splitPane = useWorkspaceStore((state) => state.splitPane);
-  const openTabIds = useOpenTabIds();
-
-  // Tabs not yet open anywhere are eligible to seed a new pane.
-  const availableTabs = WORKSPACE_TABS.filter((tab) => !openTabIds.includes(tab.id));
-  const canSplit = availableTabs.length > 0;
-
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false);
-    };
-    document.addEventListener('mousedown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
-    };
-  }, [open]);
-
-  const [direction, setDirection] = useState<SplitDirection>('right');
-
-  const handleSplit = (tabId: WorkspaceTabId) => {
-    splitPane(paneId, tabId, direction);
-    setOpen(false);
-  };
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        onClick={() => canSplit && setOpen((value) => !value)}
-        disabled={!canSplit}
-        title={canSplit ? 'Split pane' : 'All tabs are already open'}
-        className={`rounded-md p-1.5 transition-colors ${
-          canSplit
-            ? 'text-[color:var(--text-muted)] hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)]'
-            : 'cursor-not-allowed text-[color:var(--text-muted)] opacity-40'
-        }`}
-        aria-haspopup="menu"
-        aria-expanded={open}
-      >
-        <SplitSquareHorizontal size={16} />
-      </button>
-
-      {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-[calc(100%+4px)] z-50 w-56 rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] py-1 shadow-lg shadow-black/20"
-        >
-          <div className="flex items-center gap-1 border-b border-[color:var(--border-subtle)] px-2 pb-1.5 pt-1">
-            {SPLIT_OPTIONS.map((option) => (
-              <button
-                type="button"
-                key={option.direction}
-                onClick={() => setDirection(option.direction)}
-                title={option.label}
-                className={`flex flex-1 items-center justify-center rounded p-1.5 transition-colors ${
-                  direction === option.direction
-                    ? 'bg-[color:var(--surface-accent)] text-[color:var(--text-primary)]'
-                    : 'text-[color:var(--text-muted)] hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]'
-                }`}
-              >
-                {option.direction === 'right' || option.direction === 'left' ? (
-                  <SplitSquareHorizontal
-                    size={15}
-                    style={
-                      option.direction === 'left'
-                        ? ({ transform: 'scaleX(-1)' } as CSSProperties)
-                        : undefined
-                    }
-                  />
-                ) : (
-                  <SplitSquareVertical
-                    size={15}
-                    style={
-                      option.direction === 'above'
-                        ? ({ transform: 'scaleY(-1)' } as CSSProperties)
-                        : undefined
-                    }
-                  />
-                )}
-              </button>
-            ))}
-          </div>
-          <div className="max-h-64 overflow-y-auto py-1">
-            <p className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--text-muted)]">
-              Open in new pane
-            </p>
-            {availableTabs.map((tab) => (
-              <button
-                type="button"
-                key={tab.id}
-                onClick={() => handleSplit(tab.id)}
-                className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm text-[color:var(--text-secondary)] transition-colors hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]"
-              >
-                <tab.icon size={15} className="shrink-0" />
-                <span className="flex-1 truncate">{tab.label}</span>
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-/**
- * Renderer for a single dockview panel. dockview re-invokes this with fresh
- * `props.params` whenever `updateParameters` runs, so reading `props.params.tabId`
- * reflects tab switches without extra state.
+ * Renderer for a single dockview panel's *content*. The pane's header bar (view
+ * label + view switcher + split + close) lives in the custom dockview tab
+ * ({@link PaneHeaderTab}) so the header is draggable to reposition the pane;
+ * this component renders only the scrollable view body.
  *
- * Layout: a fixed header bar (tab picker + split + close) above a scrollable body
- * that hosts the selected page wrapped in {@link WorkspaceProvider}. An empty pane
- * shows a centered picker prompting the user to pick a tab.
+ * dockview re-invokes this with fresh `props.params` whenever `updateParameters`
+ * runs, so reading `props.params.tabId` reflects tab switches without extra
+ * state. An empty pane shows a centered picker prompting the user to pick a tab.
  */
 export function WorkspacePane(props: IDockviewPanelProps<WorkspacePaneParams>) {
   const paneId = props.api.id;
   const tabId = readTabId(props.params);
   const instanceName = useHostInstanceName();
 
-  const closePane = useWorkspaceStore((state) => state.closePane);
-
   const tab = tabId ? getWorkspaceTab(tabId) : undefined;
   const TabComponent = tab?.component;
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden bg-[color:var(--surface-0)] text-[color:var(--text-primary)]">
-      {/* Header bar */}
-      <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] px-2">
-        <div className="flex min-w-0 items-center gap-1">
-          <TabPicker paneId={paneId} activeTabId={tabId} variant="header" />
-        </div>
-        <div className="flex shrink-0 items-center gap-0.5">
-          <SplitMenu paneId={paneId} />
-          <button
-            type="button"
-            onClick={() => closePane(paneId)}
-            title="Close pane"
-            className="rounded-md p-1.5 text-[color:var(--text-muted)] transition-colors hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)]"
-          >
-            <X size={16} />
-          </button>
-        </div>
-      </div>
-
-      {/* Body */}
       <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden bg-[color:var(--app-bg)]">
         {TabComponent ? (
           <WorkspaceProvider instanceName={instanceName} workspaceMode>

--- a/apps/frontend/sentinel/src/components/workspace/tabs/DesktopTab.tsx
+++ b/apps/frontend/sentinel/src/components/workspace/tabs/DesktopTab.tsx
@@ -1,0 +1,626 @@
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  Copy,
+  Expand,
+  ExternalLink,
+  Globe,
+  HelpCircle,
+  Loader2,
+  MonitorOff,
+  RefreshCw,
+  RotateCcw,
+  Settings2,
+  Trash2,
+  XCircle,
+} from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { DesktopPreview } from '../../session/DesktopPreview';
+import { useSessionDeleteConfirmation } from '../../session/SessionDeleteConfirmDialog';
+import {
+  DESKTOP_RESOLUTION_PRESETS,
+  useSessionRuntimeStream,
+} from '../../../hooks/useSessionRuntimeStream';
+import { getSessionDeleteWorkspaceSummary } from '../../../lib/sessionDeletion';
+import { instanceRoute } from '../../../lib/routes';
+import { useActiveSessionId } from '../../../store/active-session-store';
+import { useInstanceName } from '../../../lib/workspace-context';
+import type { RuntimeStatusCheck } from '../../../types/api';
+
+/**
+ * Standalone Desktop workspace tab.
+ *
+ * Renders the noVNC interactive view for the workspace-wide active session,
+ * mirroring the Runtime → Desktop sub-view in SessionsPage. It consumes the
+ * SHARED, ref-counted session stream (`useSessionRuntimeStream`) so opening this
+ * tab alongside the chat / other runtime tabs for the same session yields a
+ * single WebSocket — zero duplicated stream/live-view logic.
+ *
+ * Parity with the Runtime Desktop view:
+ *   - noVNC connect/disconnect/reconnect (handled inside DesktopPreview);
+ *   - fullscreen toggle;
+ *   - resolution/geometry select (drives `applyDesktopResolution` + layoutKey);
+ *   - maintenance menu (reset browser / restart desktop / wipe workspace);
+ *   - runtime health-check diagnostics panel;
+ *   - booting state while the runtime spins up;
+ *   - per-session live-view fetch (enabled/available/url/ws_url), gated by
+ *     `desktopViewActive` — always true here since this tab *is* the surface.
+ *   - onFrameLoad / onInteract hooks (the composer-focus behavior is specific to
+ *     SessionsPage's chat; here they are harmless no-ops).
+ */
+
+/** Selectable resolutions, labelled here from the hook's single preset source. */
+const DESKTOP_RESOLUTION_OPTIONS = DESKTOP_RESOLUTION_PRESETS.map((value) => {
+  const [w, h] = value.split('x');
+  return { value, label: `${w} x ${h}` };
+});
+
+const COMMAND_HINT_RE =
+  /^(sudo |mkdir |chown |chmod |systemctl |service |brew |apt |apt-get |yum |dnf |pacman |scp |ssh |docker |npm |pip |uv |cargo |go )/;
+
+export function DesktopTab() {
+  const activeSessionId = useActiveSessionId();
+  const instanceName = useInstanceName() ?? null;
+  const navigate = useNavigate();
+
+  const [isDesktopFullscreen, setIsDesktopFullscreen] = useState(false);
+  const [resetMenuOpen, setResetMenuOpen] = useState(false);
+  const [showPassingRuntimeChecks, setShowPassingRuntimeChecks] = useState(false);
+  const [showOptionalRuntimeWarnings, setShowOptionalRuntimeWarnings] = useState(false);
+  const resetMenuRef = useRef<HTMLDivElement>(null);
+
+  const { confirmSessionDelete, sessionDeleteConfirmDialog } = useSessionDeleteConfirmation();
+
+  // `desktopViewActive: true` — this tab IS the desktop surface, so the
+  // live-view poll + runtime-status fetch should run while it is mounted.
+  const {
+    liveView,
+    isDesktopRuntimeStarting,
+    desktopResolution,
+    isDesktopResolutionChanging,
+    applyDesktopResolution,
+    desktopLayoutNonce,
+    runtimeStatus,
+    runtimeStatusLoading,
+    fetchRuntimeStatus,
+    runtimeActionBusy,
+    resetBrowser,
+    restartDesktop,
+    wipeWorkspace,
+  } = useSessionRuntimeStream(instanceName, activeSessionId, {
+    desktopViewActive: true,
+  });
+
+  // Close the maintenance menu on any click outside it (the original lived on a
+  // `resetMenuRef` guard).
+  useEffect(() => {
+    if (!resetMenuOpen) return undefined;
+    const onPointerDown = (event: MouseEvent) => {
+      if (resetMenuRef.current && !resetMenuRef.current.contains(event.target as Node)) {
+        setResetMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [resetMenuOpen]);
+
+  const handleWipeWorkspace = useCallback(() => {
+    void wipeWorkspace({
+      confirm: async () => {
+        const sid = activeSessionId;
+        if (!sid) return false;
+        const workspaceSummary = await getSessionDeleteWorkspaceSummary(sid);
+        return confirmSessionDelete({
+          kind: 'workspace_wipe',
+          label: 'Session',
+          topLevelEntries: workspaceSummary.topLevelEntries,
+        });
+      },
+    });
+  }, [wipeWorkspace, activeSessionId, confirmSessionDelete]);
+
+  // onFrameLoad/onInteract drive composer-focus restoration inside
+  // SessionsPage's chat. There is no composer in this standalone tab, so they
+  // are intentionally no-ops here — kept wired for prop parity.
+  const handleDesktopFrameLoad = useCallback(() => {}, []);
+  const handleDesktopInteract = useCallback(() => {}, []);
+
+  const isLiveViewReady = Boolean(liveView?.enabled && liveView?.available);
+
+  if (!activeSessionId) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center">
+        <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] p-3 text-[color:var(--text-muted)]">
+          <MonitorOff size={22} />
+        </div>
+        <div className="text-[10px] font-bold uppercase tracking-widest text-[color:var(--text-muted)]">
+          No active session
+        </div>
+        <p className="max-w-[280px] text-[11px] leading-relaxed text-[color:var(--text-muted)]">
+          Open a session in the Sessions tab to view its interactive desktop here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {sessionDeleteConfirmDialog}
+      <div
+        className={`relative flex items-center justify-between border-b border-[color:var(--border-subtle)] p-3 ${
+          isDesktopFullscreen ? 'z-10' : 'z-[110]'
+        }`}
+      >
+        <div className="flex items-center gap-2">
+          <Globe size={15} className="text-sky-500" />
+          <span className="text-[10px] font-bold uppercase tracking-widest text-[color:var(--text-muted)]">
+            Interactive View
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <select
+            value={desktopResolution}
+            onChange={(event) => void applyDesktopResolution(event.target.value)}
+            disabled={isDesktopResolutionChanging || isDesktopRuntimeStarting}
+            className="h-7 max-w-[126px] rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-2 font-mono text-[10px] font-bold text-[color:var(--text-secondary)] outline-none transition-colors hover:bg-[color:var(--surface-2)] disabled:opacity-50"
+            title="Desktop resolution"
+          >
+            {DESKTOP_RESOLUTION_OPTIONS.map((preset) => (
+              <option key={preset.value} value={preset.value}>
+                {preset.label}
+              </option>
+            ))}
+          </select>
+          {/* Maintenance menu */}
+          <div className={`relative ${isDesktopFullscreen ? 'z-10' : 'z-[120]'}`} ref={resetMenuRef}>
+            <button
+              onClick={() => setResetMenuOpen((o) => !o)}
+              disabled={runtimeActionBusy}
+              className="rounded-md p-1.5 text-[color:var(--text-muted)] transition-colors hover:bg-[color:var(--surface-2)] disabled:opacity-50"
+              title="Runtime actions"
+            >
+              {runtimeActionBusy ? (
+                <RotateCcw size={14} className="animate-spin" />
+              ) : (
+                <Settings2 size={14} />
+              )}
+            </button>
+            {resetMenuOpen && (
+              <div
+                className={`absolute right-0 top-full mt-1 w-48 overflow-hidden rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] shadow-xl ${
+                  isDesktopFullscreen ? 'z-10' : 'z-[130]'
+                }`}
+              >
+                <button
+                  className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-[11px] font-medium text-[color:var(--text-primary)] transition-colors hover:bg-[color:var(--surface-2)]"
+                  onClick={() => {
+                    setResetMenuOpen(false);
+                    void resetBrowser();
+                  }}
+                >
+                  <RotateCcw size={13} className="shrink-0 text-rose-400" />
+                  <div>
+                    <div className="font-semibold">Reset Browser</div>
+                    <div className="text-[9px] text-[color:var(--text-muted)]">Wipe Chrome profile</div>
+                  </div>
+                </button>
+                <div className="h-px bg-[color:var(--border-subtle)]" />
+                <button
+                  className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-[11px] font-medium text-[color:var(--text-primary)] transition-colors hover:bg-[color:var(--surface-2)]"
+                  onClick={() => {
+                    setResetMenuOpen(false);
+                    void restartDesktop();
+                  }}
+                >
+                  <RefreshCw size={13} className="shrink-0 text-amber-400" />
+                  <div>
+                    <div className="font-semibold">Restart Desktop</div>
+                    <div className="text-[9px] text-[color:var(--text-muted)]">Restart VNC session</div>
+                  </div>
+                </button>
+                <div className="h-px bg-[color:var(--border-subtle)]" />
+                <button
+                  className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-[11px] font-medium text-rose-300 transition-colors hover:bg-rose-500/10"
+                  onClick={() => {
+                    setResetMenuOpen(false);
+                    handleWipeWorkspace();
+                  }}
+                >
+                  <Trash2 size={13} className="shrink-0 text-rose-400" />
+                  <div>
+                    <div className="font-semibold">Wipe Workspace</div>
+                    <div className="text-[9px] text-[color:var(--text-muted)]">Delete session files</div>
+                  </div>
+                </button>
+              </div>
+            )}
+          </div>
+          <button
+            onClick={() => setIsDesktopFullscreen(true)}
+            className="rounded-md p-1.5 text-sky-500 transition-colors hover:bg-[color:var(--surface-2)]"
+            title="Open fullscreen"
+          >
+            <Expand size={14} />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="relative aspect-[16/10] w-full overflow-hidden border-b border-[color:var(--border-subtle)] bg-black">
+          <DesktopPreview
+            url={isLiveViewReady ? liveView!.url : null}
+            wsUrl={isLiveViewReady ? liveView!.ws_url : null}
+            isFullscreen={isDesktopFullscreen}
+            onClose={() => setIsDesktopFullscreen(false)}
+            isBooting={isDesktopRuntimeStarting && !isLiveViewReady}
+            layoutKey={`desktop-tab:${desktopLayoutNonce}:${liveView?.geometry ?? desktopResolution}`}
+            onFrameLoad={handleDesktopFrameLoad}
+            onInteract={handleDesktopInteract}
+          />
+        </div>
+
+        <div className="space-y-4 p-3">
+          <section>
+            <div className="mb-2.5 px-1 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-muted)]">
+              Desktop Status
+            </div>
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)]/50 p-3 transition-all hover:bg-[color:var(--surface-1)]">
+                <span className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--text-secondary)]">
+                  Connection
+                </span>
+                <div className="flex items-center gap-2">
+                  {isLiveViewReady ? (
+                    <>
+                      <div className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.4)]" />
+                      <span className="font-mono text-[10px] font-bold text-emerald-500">CONNECTED</span>
+                    </>
+                  ) : isDesktopRuntimeStarting ? (
+                    <>
+                      <div className="h-1.5 w-1.5 animate-pulse rounded-full bg-sky-400" />
+                      <span className="font-mono text-[10px] font-bold text-sky-400">STARTING</span>
+                    </>
+                  ) : (
+                    <>
+                      <div className="h-1.5 w-1.5 rounded-full bg-rose-500" />
+                      <span className="font-mono text-[10px] font-bold uppercase text-rose-500">
+                        {liveView?.enabled ? 'UNREACHABLE' : 'DISABLED'}
+                      </span>
+                    </>
+                  )}
+                </div>
+              </div>
+              <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)]/50 p-3 transition-all hover:bg-[color:var(--surface-1)]">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="shrink-0 text-[9px] font-bold uppercase tracking-widest text-[color:var(--text-muted)]">
+                    Stream URL
+                  </span>
+                  <div className="min-w-0 flex-1 truncate text-right font-mono text-[10px] text-[color:var(--text-secondary)]">
+                    {liveView?.ws_url || liveView?.url || '—'}
+                  </div>
+                </div>
+                {liveView?.reason && (
+                  <div className="mt-1 truncate text-right text-[9px] font-medium italic leading-relaxed text-amber-500/80">
+                    {liveView.reason}
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+
+          {(() => {
+            const overall = runtimeStatus?.status;
+            const allChecks = runtimeStatus?.checks ?? [];
+            const failed = allChecks.filter((c) => c.status === 'fail' || c.status === 'warn');
+            const requiredFailures = failed.filter((c) => c.required);
+            const optionalWarnings = failed.filter((c) => !c.required);
+            const passed = allChecks.filter((c) => c.status === 'pass');
+            const skipped = allChecks.filter((c) => c.status === 'skip');
+            const totalPassMs = passed.reduce((sum, c) => sum + (c.duration_ms ?? 0), 0);
+            const primaryFailure = requiredFailures[0] ?? null;
+            const remainingRequiredFailures = requiredFailures.slice(1);
+            const suppressPassedRollup = overall === 'unreachable' || overall === 'failed';
+
+            const heroIcon =
+              overall === 'ready' ? <CheckCircle2 size={16} className="mt-0.5 shrink-0 text-emerald-400" /> :
+              overall === 'degraded' ? <AlertCircle size={16} className="mt-0.5 shrink-0 text-amber-400" /> :
+              overall === 'unreachable' || overall === 'failed' ? <XCircle size={16} className="mt-0.5 shrink-0 text-rose-500" /> :
+              overall === 'not_configured' ? <HelpCircle size={16} className="mt-0.5 shrink-0 text-[color:var(--text-muted)]" /> :
+              <Loader2 size={16} className="mt-0.5 shrink-0 animate-spin text-[color:var(--text-muted)]" />;
+
+            const heroLabel =
+              overall === 'ready' ? 'Ready' :
+              overall === 'degraded' ? 'Degraded' :
+              overall === 'unreachable' ? 'Unreachable' :
+              overall === 'failed' ? 'Failed' :
+              overall === 'not_configured' ? 'Not configured' :
+              runtimeStatusLoading ? 'Checking…' : 'Unknown';
+
+            const heroBorder =
+              overall === 'ready' ? 'border-emerald-500/30 bg-emerald-500/5' :
+              overall === 'degraded' ? 'border-amber-500/30 bg-amber-500/5' :
+              overall === 'unreachable' || overall === 'failed' ? 'border-rose-500/30 bg-rose-500/5' :
+              'border-[color:var(--border-subtle)] bg-[color:var(--surface-1)]/50';
+
+            const targetLine = runtimeStatus?.runtime
+              ? [
+                  runtimeStatus.runtime.name,
+                  runtimeStatus.runtime.host && `${runtimeStatus.runtime.host}:${runtimeStatus.runtime.port ?? 22}`,
+                ].filter(Boolean).join(' · ')
+              : null;
+
+            const settingsHref = instanceName ? instanceRoute(instanceName, 'settings') : '/';
+            const looksLikeCommand = (text: string) => COMMAND_HINT_RE.test(text.trim());
+
+            const renderFixCallout = (check: RuntimeStatusCheck) => {
+              const isConfigFailure = check.id.startsWith('config_');
+              const hintIsCommand = check.hint ? looksLikeCommand(check.hint) : false;
+              if (!check.hint && !isConfigFailure) return null;
+              return (
+                <div className="space-y-1.5 rounded-md border-l-2 border-amber-500/50 bg-[color:var(--surface-1)]/40 py-1.5 pl-2 pr-1.5">
+                  {check.hint && hintIsCommand ? (
+                    <div className="flex items-start gap-1.5">
+                      <code className="flex-1 break-all font-mono text-[10px] leading-snug text-[color:var(--text-primary)]">
+                        {check.hint}
+                      </code>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void navigator.clipboard.writeText(check.hint ?? '');
+                          toast.success('Copied');
+                        }}
+                        className="shrink-0 rounded p-0.5 text-[color:var(--text-muted)] transition-colors hover:text-[color:var(--accent-solid)]"
+                        title="Copy to clipboard"
+                      >
+                        <Copy size={10} />
+                      </button>
+                    </div>
+                  ) : check.hint ? (
+                    <div className="text-[10px] leading-snug text-[color:var(--text-secondary)]">{check.hint}</div>
+                  ) : null}
+                  {isConfigFailure && (
+                    <button
+                      type="button"
+                      onClick={() => navigate(settingsHref)}
+                      className="inline-flex items-center gap-1 text-[9px] font-bold uppercase tracking-widest text-[color:var(--accent-solid)] transition-opacity hover:opacity-70"
+                    >
+                      Open Settings <ExternalLink size={9} />
+                    </button>
+                  )}
+                </div>
+              );
+            };
+
+            return (
+              <section className="space-y-2">
+                {/* Hero card — absorbs the primary required failure when one exists */}
+                <div className={`rounded-lg border px-2.5 py-2 ${heroBorder}`}>
+                  <div className="flex items-start gap-2">
+                    {heroIcon}
+                    <div className="min-w-0 flex-1 space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-[12px] font-bold text-[color:var(--text-primary)]">{heroLabel}</span>
+                        {targetLine && (
+                          <span className="truncate font-mono text-[10px] text-[color:var(--text-muted)]">
+                            {targetLine}
+                          </span>
+                        )}
+                      </div>
+                      {primaryFailure ? (
+                        <>
+                          <div className="text-[10px] leading-snug text-[color:var(--text-secondary)]">
+                            <span className="font-semibold text-[color:var(--text-primary)]">
+                              {primaryFailure.label}
+                            </span>{' '}
+                            failed
+                            {typeof primaryFailure.duration_ms === 'number' &&
+                              primaryFailure.duration_ms >= 500 && (
+                                <span className="font-mono text-[color:var(--text-muted)]">
+                                  {' '}
+                                  · {primaryFailure.duration_ms}ms
+                                </span>
+                              )}
+                          </div>
+                          {primaryFailure.detail && (
+                            <div className="break-words font-mono text-[10px] leading-snug text-[color:var(--text-secondary)]">
+                              {primaryFailure.detail}
+                            </div>
+                          )}
+                          {renderFixCallout(primaryFailure)}
+                        </>
+                      ) : (
+                        (runtimeStatus?.summary || runtimeStatusLoading) && (
+                          <div className="text-[10px] leading-snug text-[color:var(--text-secondary)]">
+                            {runtimeStatus?.summary ?? 'Checking runtime status…'}
+                          </div>
+                        )
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => void fetchRuntimeStatus()}
+                      disabled={runtimeStatusLoading}
+                      className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-[color:var(--text-muted)] hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] disabled:opacity-50"
+                      title="Refresh runtime diagnostics"
+                    >
+                      <RefreshCw size={11} className={runtimeStatusLoading ? 'animate-spin' : ''} />
+                    </button>
+                  </div>
+                </div>
+
+                {/* Additional required failures, if any (rare — usually there's just one). */}
+                {remainingRequiredFailures.length > 0 && (
+                  <div className="space-y-1.5">
+                    {remainingRequiredFailures.map((check) => (
+                      <div
+                        key={check.id}
+                        className="rounded-lg border border-rose-500/30 bg-rose-500/5 px-2.5 py-2"
+                      >
+                        <div className="flex items-start gap-2">
+                          <XCircle size={13} className="mt-0.5 shrink-0 text-rose-500" />
+                          <div className="min-w-0 flex-1 space-y-1">
+                            <div className="text-[11px] font-bold text-[color:var(--text-primary)]">
+                              {check.label}
+                            </div>
+                            {check.detail && (
+                              <div className="break-words font-mono text-[10px] leading-snug text-[color:var(--text-secondary)]">
+                                {check.detail}
+                              </div>
+                            )}
+                            {renderFixCallout(check)}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Optional warnings — collapsed roll-up */}
+                {optionalWarnings.length > 0 && (
+                  <div className="space-y-1">
+                    <button
+                      type="button"
+                      onClick={() => setShowOptionalRuntimeWarnings((v) => !v)}
+                      className="flex w-full items-center justify-between gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 px-2.5 py-1.5 text-left transition-all hover:bg-amber-500/10"
+                    >
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <AlertCircle size={11} className="shrink-0 text-amber-400" />
+                        <span className="text-[10px] font-medium text-[color:var(--text-secondary)]">
+                          {optionalWarnings.length} optional capabilit
+                          {optionalWarnings.length === 1 ? 'y' : 'ies'} missing
+                        </span>
+                      </div>
+                      <ChevronDown
+                        size={11}
+                        className={`shrink-0 text-[color:var(--text-muted)] transition-transform ${
+                          showOptionalRuntimeWarnings ? 'rotate-180' : ''
+                        }`}
+                      />
+                    </button>
+                    {showOptionalRuntimeWarnings && (
+                      <div className="space-y-1 rounded-lg bg-[color:var(--surface-1)]/30 px-2 py-1.5">
+                        {optionalWarnings.map((check) => (
+                          <div key={check.id} className="flex items-start gap-1.5 py-0.5">
+                            <div className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-amber-400" />
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-baseline gap-1.5">
+                                <span className="text-[10px] font-semibold text-[color:var(--text-secondary)]">
+                                  {check.label}
+                                </span>
+                                {check.detail && (
+                                  <span className="truncate font-mono text-[9px] text-[color:var(--text-muted)]">
+                                    {check.detail}
+                                  </span>
+                                )}
+                              </div>
+                              {check.hint && (
+                                <div className="text-[9px] leading-snug text-[color:var(--text-muted)]">
+                                  {check.hint}
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Passing checks collapsed — hidden when the runtime is unreachable/failed */}
+                {passed.length > 0 && !suppressPassedRollup && (
+                  <div className="space-y-1">
+                    <button
+                      type="button"
+                      onClick={() => setShowPassingRuntimeChecks((v) => !v)}
+                      className="flex w-full items-center justify-between gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)]/40 px-2.5 py-1.5 text-left transition-all hover:bg-[color:var(--surface-1)]"
+                    >
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <CheckCircle2 size={11} className="shrink-0 text-emerald-400" />
+                        <span className="text-[10px] font-medium text-[color:var(--text-secondary)]">
+                          {passed.length} check{passed.length === 1 ? '' : 's'} passed
+                          {totalPassMs > 0 ? ` · ${totalPassMs}ms` : ''}
+                        </span>
+                      </div>
+                      <ChevronDown
+                        size={11}
+                        className={`shrink-0 text-[color:var(--text-muted)] transition-transform ${
+                          showPassingRuntimeChecks ? 'rotate-180' : ''
+                        }`}
+                      />
+                    </button>
+                    {showPassingRuntimeChecks && (
+                      <div className="space-y-0.5 rounded-lg bg-[color:var(--surface-1)]/30 px-2 py-1.5">
+                        {passed.map((check) => (
+                          <div key={check.id} className="flex items-center gap-1.5 py-0.5">
+                            <div className="h-1 w-1 shrink-0 rounded-full bg-emerald-500" />
+                            <span className="min-w-0 flex-1 truncate text-[10px] text-[color:var(--text-secondary)]">
+                              {check.label}
+                            </span>
+                            {typeof check.duration_ms === 'number' && check.duration_ms >= 100 && (
+                              <span className="shrink-0 font-mono text-[9px] text-[color:var(--text-muted)]">
+                                {check.duration_ms}ms
+                              </span>
+                            )}
+                          </div>
+                        ))}
+                        {skipped.map((check) => (
+                          <div key={check.id} className="flex items-center gap-1.5 py-0.5 opacity-50">
+                            <div className="h-1 w-1 shrink-0 rounded-full bg-[color:var(--text-muted)]" />
+                            <span className="min-w-0 flex-1 truncate text-[10px] text-[color:var(--text-muted)]">
+                              {check.label} (skipped)
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Empty / loading states */}
+                {!runtimeStatus && runtimeStatusLoading && allChecks.length === 0 && (
+                  <div className="py-3 text-center text-[10px] text-[color:var(--text-muted)] opacity-60">
+                    Checking runtime…
+                  </div>
+                )}
+                {!runtimeStatus && !runtimeStatusLoading && (
+                  <div className="py-3 text-center text-[10px] text-[color:var(--text-muted)] opacity-40">
+                    No diagnostics yet.
+                  </div>
+                )}
+
+                {/* Footer metadata */}
+                {runtimeStatus?.runtime &&
+                  (runtimeStatus.runtime.username || runtimeStatus.runtime.workspaces_dir) && (
+                    <div className="space-y-0 px-1 pt-0.5 font-mono text-[9px] text-[color:var(--text-muted)]">
+                      <div className="truncate">
+                        {[
+                          runtimeStatus.os !== 'unknown' ? runtimeStatus.os : null,
+                          runtimeStatus.sandbox !== 'unknown' && runtimeStatus.sandbox !== 'unavailable'
+                            ? `${runtimeStatus.sandbox} sandbox`
+                            : null,
+                          runtimeStatus.runtime.username && runtimeStatus.runtime.host
+                            ? `${runtimeStatus.runtime.username}@${runtimeStatus.runtime.host}:${
+                                runtimeStatus.runtime.port ?? 22
+                              }`
+                            : null,
+                        ]
+                          .filter(Boolean)
+                          .join(' · ')}
+                      </div>
+                      {runtimeStatus.runtime.workspaces_dir && (
+                        <div className="truncate">{runtimeStatus.runtime.workspaces_dir}</div>
+                      )}
+                    </div>
+                  )}
+              </section>
+            );
+          })()}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/sentinel/src/hooks/useSessionRuntimeStream.ts
+++ b/apps/frontend/sentinel/src/hooks/useSessionRuntimeStream.ts
@@ -1,0 +1,583 @@
+import type React from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+import { api } from '../lib/api';
+import { isSessionStreamOpen, sendSessionStreamMessage } from '../lib/session-stream';
+import { useSessionStream } from './useSessionStream';
+import type {
+  RuntimeActionResponse,
+  RuntimeLiveView,
+  RuntimeStatusResponse,
+  WsConnectionState,
+  WsEvent,
+} from '../types/api';
+
+/**
+ * One live terminal surfaced by the runtime. Mirrors the shape SessionsPage has
+ * always used to render the terminal strip and pills.
+ */
+export interface ActiveTerminal {
+  id: string;
+  /** Backend-supplied label, used only as a fallback for auto-allocated terminals. */
+  label: string | null;
+  createdBy: 'agent' | 'user';
+  createdAt: number;
+  auto: boolean;
+  busy: boolean;
+  /** Most recent command run in this terminal (for tooltip + rail header). */
+  lastCommand: string | null;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseTerminal(raw: unknown): ActiveTerminal | null {
+  if (!isObjectRecord(raw)) return null;
+  const id = typeof raw.terminal_id === 'string' ? raw.terminal_id : null;
+  if (!id) return null;
+  return {
+    id,
+    label: typeof raw.label === 'string' ? raw.label : null,
+    createdBy: raw.created_by === 'user' ? 'user' : 'agent',
+    createdAt: typeof raw.created_at === 'number' ? raw.created_at : Date.now() / 1000,
+    auto: Boolean(raw.auto),
+    busy: false,
+    lastCommand: typeof raw.last_command === 'string' ? raw.last_command : null,
+  };
+}
+
+export interface UseSessionRuntimeStreamOptions {
+  /**
+   * Fired when a terminal opens and the pill row was previously empty (i.e. the
+   * first terminal of the session). Lets the consumer implement its own
+   * auto-focus rule without baking UI concerns into the hook.
+   */
+  onFirstTerminalOpened?: () => void;
+  /**
+   * Whether the desktop/live-view surface is currently visible. Gates the
+   * live-view poll + runtime-status fetch exactly as SessionsPage did.
+   */
+  desktopViewActive?: boolean;
+  /** Fired when reconnect attempts are exhausted (mirrors the old toast). */
+  onReconnectFailed?: () => void;
+  /**
+   * Extra raw-event tap. The runtime hook handles terminal/runtime_ready events
+   * itself; the consumer uses this to drive its own (chat) state from the same
+   * shared socket without opening a second connection.
+   */
+  onEvent?: (event: WsEvent) => void;
+}
+
+/**
+ * Hooks for the destructive `wipeWorkspace` action. The network call + booting
+ * side effects live in the hook, but the confirmation prompt and any
+ * file-browser refresh are UI concerns owned by the consumer.
+ */
+export interface WipeWorkspaceOptions {
+  /**
+   * Resolve `true` to proceed with the wipe, `false` to cancel. When omitted the
+   * wipe runs immediately (no confirmation). Returning `false` short-circuits
+   * before `runtimeActionBusy` is set.
+   */
+  confirm?: () => Promise<boolean> | boolean;
+  /** Fired after a successful wipe (e.g. to refresh a file browser). */
+  onWiped?: (sessionId: string) => void;
+}
+
+export interface UseSessionRuntimeStreamResult {
+  // connection
+  connection: WsConnectionState;
+  /** Whether the shared socket is OPEN and writable. */
+  isStreamOpen: () => boolean;
+  /** Send a JSON payload over the shared socket; false if not OPEN. */
+  sendMessage: (payload: unknown) => boolean;
+
+  // terminals
+  activeTerminals: ActiveTerminal[];
+  focusedTerminalId: string | null;
+  setFocusedTerminalId: (terminalId: string | null) => void;
+  /**
+   * Optimistically drop a terminal pill (e.g. on a user-initiated close) and
+   * clear focus if it was focused. The authoritative `terminal_closed` event is
+   * idempotent against this.
+   */
+  dropTerminal: (terminalId: string) => void;
+
+  // live view
+  liveView: RuntimeLiveView | null;
+  setLiveView: React.Dispatch<React.SetStateAction<RuntimeLiveView | null>>;
+  runtimeBooting: boolean;
+  setRuntimeBooting: React.Dispatch<React.SetStateAction<boolean>>;
+  /** Desktop is starting when live view is enabled-but-unavailable, or booting. */
+  isDesktopRuntimeStarting: boolean;
+  fetchLiveView: () => Promise<void>;
+
+  // desktop resolution
+  desktopResolution: string;
+  /** Local-only set + persist (no POST). Used by the validation guard. */
+  setDesktopResolution: (geometry: string) => void;
+  /** Whether a resolution-change POST is in flight. */
+  isDesktopResolutionChanging: boolean;
+  /** Persist + POST a new geometry to the runtime, updating live view. */
+  applyDesktopResolution: (geometry: string) => Promise<void>;
+  /** Layout nonce, bumped on resolution change so DesktopPreview's RFB remounts. */
+  desktopLayoutNonce: number;
+
+  // runtime status
+  runtimeStatus: RuntimeStatusResponse | null;
+  runtimeStatusLoading: boolean;
+  fetchRuntimeStatus: () => Promise<void>;
+
+  // per-session runtime maintenance
+  /** True while any of the maintenance actions below is in flight. */
+  runtimeActionBusy: boolean;
+  /** Wipe the runtime's Chrome profile and re-fetch the live view. */
+  resetBrowser: () => Promise<void>;
+  /** Restart the VNC desktop at the current resolution and re-fetch live view. */
+  restartDesktop: () => Promise<void>;
+  /** Delete the session's runtime workspace files (optionally confirmed first). */
+  wipeWorkspace: (options?: WipeWorkspaceOptions) => Promise<void>;
+}
+
+const DEFAULT_DESKTOP_RESOLUTION = '1920x1200';
+const DESKTOP_RESOLUTION_STORAGE_KEY = 'sentinel-desktop-resolution';
+
+/**
+ * Single source of truth for selectable desktop geometries. Consumers derive
+ * their own option labels from these so the list can't drift between the hook
+ * (validation guard) and the tab (resolution `<select>`).
+ */
+export const DESKTOP_RESOLUTION_PRESETS = [
+  '1280x800',
+  '1440x900',
+  '1680x1050',
+  '1920x1200',
+  '2560x1600',
+  '2880x1800',
+  '3840x2400',
+];
+
+/**
+ * Owns the per-session runtime state derived from the shared WS stream:
+ *   - the live terminal list + focus (terminal_opened/closed/busy + connected);
+ *   - the noVNC live-view payload + booting state (poll on visibility,
+ *     re-fetch on runtime_ready);
+ *   - runtime status checks.
+ *
+ * The WebSocket itself is shared and ref-counted via {@link useSessionStream},
+ * so SessionsPage and the future standalone runtime tabs that consume this hook
+ * share ONE socket per session. `onEvent` lets a consumer (SessionsPage) feed
+ * its chat state from the same stream.
+ */
+export function useSessionRuntimeStream(
+  instanceName: string | null,
+  sessionId: string | null,
+  options: UseSessionRuntimeStreamOptions = {},
+): UseSessionRuntimeStreamResult {
+  const desktopViewActive = options.desktopViewActive ?? false;
+
+  const [activeTerminals, setActiveTerminals] = useState<ActiveTerminal[]>([]);
+  const [focusedTerminalId, setFocusedTerminalId] = useState<string | null>(null);
+  const [liveView, setLiveView] = useState<RuntimeLiveView | null>(null);
+  const [runtimeBooting, setRuntimeBooting] = useState(false);
+  const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatusResponse | null>(null);
+  const [runtimeStatusLoading, setRuntimeStatusLoading] = useState(false);
+  const [desktopResolution, setDesktopResolutionState] = useState(
+    () => localStorage.getItem(DESKTOP_RESOLUTION_STORAGE_KEY) || DEFAULT_DESKTOP_RESOLUTION,
+  );
+  const [isDesktopResolutionChanging, setIsDesktopResolutionChanging] = useState(false);
+  const [desktopLayoutNonce, setDesktopLayoutNonce] = useState(0);
+  const [runtimeActionBusy, setRuntimeActionBusy] = useState(false);
+
+  // Refs so stream callbacks read current values without re-subscribing.
+  const sessionIdRef = useRef<string | null>(sessionId);
+  const instanceNameRef = useRef<string | null>(instanceName);
+  const desktopResolutionRef = useRef(desktopResolution);
+  const onFirstTerminalOpenedRef = useRef(options.onFirstTerminalOpened);
+  const onEventRef = useRef(options.onEvent);
+  // Guards the maintenance actions against re-entry without re-creating the
+  // ref-stable callbacks each time `runtimeActionBusy` flips.
+  const runtimeActionBusyRef = useRef(false);
+  // Flipped false on unmount so the long-lived `runtime_ready` retry loop can't
+  // setState after the component is gone.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
+  useEffect(() => {
+    instanceNameRef.current = instanceName;
+  }, [instanceName]);
+  useEffect(() => {
+    desktopResolutionRef.current = desktopResolution;
+  }, [desktopResolution]);
+  useEffect(() => {
+    onFirstTerminalOpenedRef.current = options.onFirstTerminalOpened;
+  }, [options.onFirstTerminalOpened]);
+  useEffect(() => {
+    onEventRef.current = options.onEvent;
+  }, [options.onEvent]);
+
+  const fetchLiveView = useCallback(async () => {
+    const sid = sessionIdRef.current;
+    if (!sid) {
+      setLiveView(null);
+      setRuntimeBooting(false);
+      return;
+    }
+    try {
+      const query = new URLSearchParams({ session_id: sid, geometry: desktopResolutionRef.current });
+      const payload = await api.get<RuntimeLiveView>(`/runtime/live-view?${query.toString()}`);
+      if (sid !== sessionIdRef.current) return;
+      setLiveView(payload);
+      if (payload.enabled && payload.available) {
+        setRuntimeBooting(false);
+      } else if (payload.enabled) {
+        setRuntimeBooting(true);
+      } else {
+        setRuntimeBooting(false);
+      }
+    } catch {
+      if (sid !== sessionIdRef.current) return;
+      setLiveView(null);
+    }
+  }, []);
+
+  const fetchRuntimeStatus = useCallback(async () => {
+    setRuntimeStatusLoading(true);
+    try {
+      const payload = await api.get<RuntimeStatusResponse>('/runtime/status');
+      setRuntimeStatus(payload);
+    } catch {
+      setRuntimeStatus(null);
+    } finally {
+      setRuntimeStatusLoading(false);
+    }
+  }, []);
+
+  const setDesktopResolution = useCallback((geometry: string) => {
+    setDesktopResolutionState(geometry);
+    localStorage.setItem(DESKTOP_RESOLUTION_STORAGE_KEY, geometry);
+  }, []);
+
+  const dropTerminal = useCallback((terminalId: string) => {
+    setActiveTerminals((current) => current.filter((t) => t.id !== terminalId));
+    setFocusedTerminalId((current) => (current === terminalId ? null : current));
+  }, []);
+
+  const isStreamOpen = useCallback(() => {
+    const inst = instanceNameRef.current;
+    const sid = sessionIdRef.current;
+    if (!inst || !sid) return false;
+    return isSessionStreamOpen(inst, sid);
+  }, []);
+
+  const sendMessage = useCallback((payload: unknown) => {
+    const inst = instanceNameRef.current;
+    const sid = sessionIdRef.current;
+    if (!inst || !sid) return false;
+    return sendSessionStreamMessage(inst, sid, payload);
+  }, []);
+
+  // Fall back to the default if a persisted resolution is no longer a preset.
+  useEffect(() => {
+    if (!DESKTOP_RESOLUTION_PRESETS.includes(desktopResolution)) {
+      setDesktopResolutionState(DEFAULT_DESKTOP_RESOLUTION);
+      localStorage.setItem(DESKTOP_RESOLUTION_STORAGE_KEY, DEFAULT_DESKTOP_RESOLUTION);
+    }
+  }, [desktopResolution]);
+
+  const applyDesktopResolution = useCallback(
+    async (geometry: string) => {
+      if (isDesktopResolutionChanging || geometry === desktopResolutionRef.current) return;
+      const sid = sessionIdRef.current;
+      if (!sid) return;
+      setDesktopResolutionState(geometry);
+      localStorage.setItem(DESKTOP_RESOLUTION_STORAGE_KEY, geometry);
+      setIsDesktopResolutionChanging(true);
+      setRuntimeBooting(true);
+      setDesktopLayoutNonce((value) => value + 1);
+      try {
+        const query = new URLSearchParams({ session_id: sid });
+        const payload = await api.post<RuntimeLiveView>(
+          `/runtime/live-view/resolution?${query.toString()}`,
+          { geometry },
+          { timeoutMs: 60_000 },
+        );
+        setLiveView(payload);
+        if (payload.enabled && payload.available) {
+          setRuntimeBooting(false);
+          setDesktopLayoutNonce((value) => value + 1);
+        } else {
+          toast.error(payload.reason || 'Desktop resolution change failed');
+        }
+      } catch {
+        toast.error('Failed to change desktop resolution');
+        setRuntimeBooting(false);
+      } finally {
+        setIsDesktopResolutionChanging(false);
+      }
+    },
+    [isDesktopResolutionChanging],
+  );
+
+  const beginRuntimeAction = useCallback(() => {
+    runtimeActionBusyRef.current = true;
+    setRuntimeActionBusy(true);
+  }, []);
+
+  const endRuntimeAction = useCallback(() => {
+    runtimeActionBusyRef.current = false;
+    setRuntimeActionBusy(false);
+  }, []);
+
+  const resetBrowser = useCallback(async () => {
+    if (runtimeActionBusyRef.current) return;
+    const sid = sessionIdRef.current;
+    if (!sid) return;
+    beginRuntimeAction();
+    try {
+      await api.post<RuntimeActionResponse>(`/runtime/browser/reset?session_id=${sid}`, {});
+      toast.success('Browser reset');
+      await fetchLiveView();
+    } catch {
+      toast.error('Failed to reset browser');
+    } finally {
+      endRuntimeAction();
+    }
+  }, [beginRuntimeAction, endRuntimeAction, fetchLiveView]);
+
+  const restartDesktop = useCallback(async () => {
+    if (runtimeActionBusyRef.current) return;
+    const sid = sessionIdRef.current;
+    if (!sid) return;
+    beginRuntimeAction();
+    setRuntimeBooting(true);
+    setLiveView(null);
+    try {
+      await api.post<RuntimeActionResponse>(
+        `/runtime/desktop/restart?session_id=${sid}`,
+        { geometry: desktopResolutionRef.current },
+        { timeoutMs: 60_000 },
+      );
+      toast.success('Desktop restarted');
+      await fetchLiveView();
+    } catch {
+      toast.error('Failed to restart desktop');
+      setRuntimeBooting(false);
+    } finally {
+      endRuntimeAction();
+    }
+  }, [beginRuntimeAction, endRuntimeAction, fetchLiveView]);
+
+  const wipeWorkspace = useCallback(
+    async (wipeOptions: WipeWorkspaceOptions = {}) => {
+      if (runtimeActionBusyRef.current) return;
+      const sid = sessionIdRef.current;
+      if (!sid) return;
+      // Confirmation is a UI concern — let the consumer gate the destructive
+      // action before we flip the busy flag or touch any state.
+      if (wipeOptions.confirm) {
+        const confirmed = await wipeOptions.confirm();
+        if (!confirmed) return;
+      }
+      beginRuntimeAction();
+      setRuntimeBooting(true);
+      setLiveView(null);
+      try {
+        await api.post<RuntimeActionResponse>(
+          `/runtime/workspace/wipe?session_id=${sid}`,
+          {},
+          { timeoutMs: 90_000 },
+        );
+        toast.success('Workspace wiped');
+        await fetchLiveView();
+        wipeOptions.onWiped?.(sid);
+      } catch {
+        toast.error('Failed to wipe workspace');
+        setRuntimeBooting(false);
+      } finally {
+        endRuntimeAction();
+      }
+    },
+    [beginRuntimeAction, endRuntimeAction, fetchLiveView],
+  );
+
+  // Reset terminal + live-view state and (re)fetch when the session changes.
+  useEffect(() => {
+    setActiveTerminals([]);
+    setFocusedTerminalId(null);
+    if (!sessionId) {
+      setLiveView(null);
+      setRuntimeBooting(false);
+      return;
+    }
+    setRuntimeBooting(true);
+    void fetchLiveView();
+  }, [sessionId, fetchLiveView]);
+
+  // Live-view poll while the desktop surface is visible and still booting.
+  useEffect(() => {
+    if (!sessionId || !desktopViewActive) return undefined;
+    if (!runtimeBooting && liveView?.enabled && liveView.available) return undefined;
+
+    let cancelled = false;
+    const refresh = async () => {
+      if (cancelled) return;
+      await fetchLiveView();
+    };
+    const interval = window.setInterval(() => {
+      void refresh();
+    }, 2000);
+    void refresh();
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [sessionId, desktopViewActive, runtimeBooting, liveView?.enabled, liveView?.available, fetchLiveView]);
+
+  // Runtime status fetch on desktop visibility / instance change.
+  useEffect(() => {
+    if (!desktopViewActive) return;
+    void fetchRuntimeStatus();
+  }, [desktopViewActive, instanceName, fetchRuntimeStatus]);
+
+  const handleEvent = useCallback((event: WsEvent) => {
+    switch (event.type) {
+      case 'connected': {
+        if (Array.isArray(event.terminals)) {
+          // Replace (not merge) so stale terminals from a previous session
+          // never linger after a reload or backend restart.
+          const incoming = (event.terminals as unknown[])
+            .map(parseTerminal)
+            .filter((item): item is ActiveTerminal => item !== null);
+          setActiveTerminals(incoming);
+        }
+        break;
+      }
+      case 'terminal_opened': {
+        const id = typeof event.terminal_id === 'string' ? event.terminal_id : null;
+        if (!id) break;
+        const label = typeof event.label === 'string' ? event.label : null;
+        const createdBy = event.created_by === 'user' ? 'user' : 'agent';
+        const auto = Boolean(event.auto);
+        let wasFirstTerminal = false;
+        setActiveTerminals((current) => {
+          if (current.some((t) => t.id === id)) {
+            return current.map((t) => (t.id === id ? { ...t, label: t.label || label } : t));
+          }
+          wasFirstTerminal = current.length === 0;
+          return [
+            ...current,
+            { id, label, createdBy, createdAt: Date.now() / 1000, auto, busy: false, lastCommand: null },
+          ];
+        });
+        if (wasFirstTerminal) {
+          onFirstTerminalOpenedRef.current?.();
+        }
+        break;
+      }
+      case 'terminal_closed': {
+        const id = typeof event.terminal_id === 'string' ? event.terminal_id : null;
+        if (!id) break;
+        setActiveTerminals((current) => current.filter((t) => t.id !== id));
+        setFocusedTerminalId((current) => (current === id ? null : current));
+        break;
+      }
+      case 'terminal_busy': {
+        const id = typeof event.terminal_id === 'string' ? event.terminal_id : null;
+        if (!id) break;
+        const busy = Boolean(event.busy);
+        const lastCommand = typeof event.last_command === 'string' ? event.last_command : undefined;
+        setActiveTerminals((current) =>
+          current.map((t) =>
+            t.id === id
+              ? { ...t, busy, lastCommand: lastCommand !== undefined ? lastCommand : t.lastCommand }
+              : t,
+          ),
+        );
+        break;
+      }
+      case 'runtime_ready': {
+        // noVNC may need a moment after the container reports ready — retry a
+        // few times before giving up on the booting flag.
+        void (async () => {
+          for (let attempt = 0; attempt < 6; attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            if (!mountedRef.current) return;
+            const sid = sessionIdRef.current;
+            if (!sid) break;
+            try {
+              const query = new URLSearchParams({ session_id: sid, geometry: desktopResolutionRef.current });
+              const payload = await api.get<RuntimeLiveView>(`/runtime/live-view?${query.toString()}`);
+              if (!mountedRef.current || sid !== sessionIdRef.current) return;
+              setLiveView(payload);
+              if (payload.enabled && payload.available) {
+                setRuntimeBooting(false);
+                return;
+              }
+            } catch {
+              /* retry */
+            }
+          }
+          if (!mountedRef.current) return;
+          const sid = sessionIdRef.current;
+          if (!sid) {
+            setRuntimeBooting(false);
+          }
+        })();
+        break;
+      }
+      default:
+        break;
+    }
+    // Forward every event to the consumer (chat state lives there).
+    onEventRef.current?.(event);
+  }, []);
+
+  const { connection } = useSessionStream(instanceName, sessionId, {
+    onEvent: handleEvent,
+    onReconnectFailed: options.onReconnectFailed,
+  });
+
+  const isDesktopRuntimeStarting = useMemo(
+    () => Boolean(liveView?.enabled && !liveView.available) || runtimeBooting,
+    [liveView?.enabled, liveView?.available, runtimeBooting],
+  );
+
+  return {
+    connection,
+    isStreamOpen,
+    sendMessage,
+    activeTerminals,
+    focusedTerminalId,
+    setFocusedTerminalId,
+    dropTerminal,
+    liveView,
+    setLiveView,
+    runtimeBooting,
+    setRuntimeBooting,
+    isDesktopRuntimeStarting,
+    fetchLiveView,
+    desktopResolution,
+    setDesktopResolution,
+    isDesktopResolutionChanging,
+    applyDesktopResolution,
+    desktopLayoutNonce,
+    runtimeStatus,
+    runtimeStatusLoading,
+    fetchRuntimeStatus,
+    runtimeActionBusy,
+    resetBrowser,
+    restartDesktop,
+    wipeWorkspace,
+  };
+}

--- a/apps/frontend/sentinel/src/hooks/useSessionStream.ts
+++ b/apps/frontend/sentinel/src/hooks/useSessionStream.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  subscribeSessionStream,
+  type SessionStreamReconnectFailedListener,
+} from '../lib/session-stream';
+import type { WsConnectionState, WsEvent } from '../types/api';
+
+export interface UseSessionStreamOptions {
+  /** Called for every parsed event on the shared socket. */
+  onEvent?: (event: WsEvent) => void;
+  /** Called once when reconnect attempts are exhausted. */
+  onReconnectFailed?: SessionStreamReconnectFailedListener;
+}
+
+export interface UseSessionStreamResult {
+  /** Live connection state of the shared socket for this session. */
+  connection: WsConnectionState;
+}
+
+/**
+ * React subscription to the shared, ref-counted session WebSocket. Multiple
+ * hooks/components subscribing to the same (instanceName, sessionId) share ONE
+ * underlying socket — opening on the first subscriber, closing on the last.
+ *
+ * Handlers are stored in refs and read through stable wrappers, so the
+ * subscription only re-runs when the session/instance changes (not on every
+ * render or handler identity change). This keeps the connection stable across
+ * parent re-renders.
+ */
+export function useSessionStream(
+  instanceName: string | null,
+  sessionId: string | null,
+  options: UseSessionStreamOptions = {},
+): UseSessionStreamResult {
+  const [connection, setConnection] = useState<WsConnectionState>('disconnected');
+
+  const onEventRef = useRef(options.onEvent);
+  const onReconnectFailedRef = useRef(options.onReconnectFailed);
+  useEffect(() => {
+    onEventRef.current = options.onEvent;
+  }, [options.onEvent]);
+  useEffect(() => {
+    onReconnectFailedRef.current = options.onReconnectFailed;
+  }, [options.onReconnectFailed]);
+
+  useEffect(() => {
+    if (!instanceName || !sessionId) {
+      setConnection('disconnected');
+      return undefined;
+    }
+
+    const subscription = subscribeSessionStream(instanceName, sessionId, {
+      onEvent: (event) => onEventRef.current?.(event),
+      onState: (state) => setConnection(state),
+      onReconnectFailed: () => onReconnectFailedRef.current?.(),
+    });
+    setConnection(subscription.connection);
+
+    return () => {
+      subscription.unsubscribe();
+      setConnection('disconnected');
+    };
+  }, [instanceName, sessionId]);
+
+  return { connection };
+}

--- a/apps/frontend/sentinel/src/hooks/useSessionWorkbench.ts
+++ b/apps/frontend/sentinel/src/hooks/useSessionWorkbench.ts
@@ -1,0 +1,589 @@
+import type React from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+import { api } from '../lib/api';
+import { buildRuntimeGitChangedTree } from '../lib/runtimeGitTree';
+import type { WorkbenchTab } from '../components/workbench/Workbench';
+import type {
+  SessionRuntimeFileEntry,
+  SessionRuntimeFilePreviewResponse,
+  SessionRuntimeFilesResponse,
+  SessionRuntimeGitChangedFilesResponse,
+  SessionRuntimeGitDiffResponse,
+  SessionRuntimeGitRoot,
+  SessionRuntimeGitRootsResponse,
+} from '../types/api';
+
+/** A repo-changes section as rendered by WorkbenchExplorerPane. */
+export interface WorkbenchRepoChangeSection {
+  id: string;
+  title: string;
+  tree: ReturnType<typeof buildRuntimeGitChangedTree>;
+  loading: boolean;
+}
+
+function buildDiffBaseRefOptions(
+  roots: SessionRuntimeGitRoot[],
+  currentRef: string | null | undefined,
+): string[] {
+  const options = new Set<string>();
+  options.add('HEAD');
+  for (const root of roots) {
+    if (!root.detached_head && root.branch) {
+      options.add(root.branch);
+      options.add(`origin/${root.branch}`);
+    }
+  }
+  options.add('origin/main');
+  options.add('origin/master');
+  const normalizedCurrent = (currentRef ?? '').trim();
+  if (normalizedCurrent) {
+    options.add(normalizedCurrent);
+  }
+  return Array.from(options);
+}
+
+export interface UseSessionWorkbenchResult {
+  // explorer (directory browse)
+  runtimeFiles: SessionRuntimeFilesResponse | null;
+  runtimePath: string;
+  runtimeFilesLoading: boolean;
+  runtimeFilesRefreshKey: number;
+  fetchRuntimeFiles: (
+    path?: string,
+    options?: { refreshGit?: boolean; silent?: boolean },
+  ) => Promise<void>;
+  bumpRuntimeFilesRefreshKey: () => void;
+  loadRuntimeDirectoryEntries: (path: string) => Promise<SessionRuntimeFileEntry[]>;
+  downloadRuntimeEntry: (entry: SessionRuntimeFileEntry) => Promise<void>;
+
+  // repo changes (git)
+  repoChangeSections: WorkbenchRepoChangeSection[];
+  expandedGitDirs: Record<string, boolean>;
+  toggleGitDir: (path: string) => void;
+  fetchChangedFilesForRepo: (path: string) => Promise<SessionRuntimeGitChangedFilesResponse | null>;
+  forgetRepoRoot: (path: string) => void;
+
+  // workbench tabs (open file → view + diff)
+  workbenchTabs: WorkbenchTab[];
+  activeWorkbenchPath: string | null;
+  setActiveWorkbenchPath: React.Dispatch<React.SetStateAction<string | null>>;
+  workbenchLoadingPath: string | null;
+  activeWorkbenchTab: WorkbenchTab | null;
+  openRuntimeFile: (path: string, options?: { suppressErrorToast?: boolean }) => Promise<boolean>;
+  openRuntimeDirectory: (path: string, options?: { autoOpenFirstDiff?: boolean }) => Promise<void>;
+  openRuntimeFileDiff: (path: string) => Promise<void>;
+  closeWorkbenchTab: (path: string) => void;
+  closeAllWorkbenchTabs: () => void;
+
+  // diff view
+  workbenchShowDiffByPath: Record<string, boolean>;
+  setShowDiffForPath: (path: string, enabled: boolean) => void;
+  activeWorkbenchDiff: SessionRuntimeGitDiffResponse | null;
+  activeWorkbenchDiffError: string | null;
+  activeWorkbenchDiffLoading: boolean;
+  activeWorkbenchBaseRef: string;
+  setDiffBaseRefForPath: (path: string, baseRef: string) => void;
+  activeWorkbenchBaseRefOptions: string[];
+  fetchRuntimeGitDiff: (path: string, options?: { baseRef?: string }) => Promise<void>;
+
+  /** Clear ALL workbench/explorer/git state (e.g. when the session goes null). */
+  resetWorkbench: () => void;
+}
+
+/**
+ * Owns the per-session files / workbench surface:
+ *   - directory browse + lazy directory load (`loadRuntimeDirectoryEntries`);
+ *   - open file to view (`openRuntimeFile`) and git diff (`openRuntimeFileDiff`);
+ *   - repo-changes sections + expanded git dirs;
+ *   - file/folder download.
+ *
+ * Every request is guarded against a stale active session via `sessionIdRef`,
+ * matching SessionsPage's behavior exactly. State resets when `sessionId`
+ * changes so a new session never shows the previous one's tree/tabs.
+ */
+export function useSessionWorkbench(sessionId: string | null): UseSessionWorkbenchResult {
+  const [runtimeFiles, setRuntimeFiles] = useState<SessionRuntimeFilesResponse | null>(null);
+  const [runtimePath, setRuntimePath] = useState('');
+  const [runtimeFilesLoading, setRuntimeFilesLoading] = useState(false);
+  const [runtimeFilesRefreshKey, setRuntimeFilesRefreshKey] = useState(0);
+
+  const [repoChangesByRoot, setRepoChangesByRoot] = useState<
+    Record<string, SessionRuntimeGitChangedFilesResponse | null>
+  >({});
+  const [repoChangesLoadingByRoot, setRepoChangesLoadingByRoot] = useState<Record<string, boolean>>({});
+  const [expandedGitDirs, setExpandedGitDirs] = useState<Record<string, boolean>>({});
+
+  const [workbenchTabs, setWorkbenchTabs] = useState<WorkbenchTab[]>([]);
+  const [activeWorkbenchPath, setActiveWorkbenchPath] = useState<string | null>(null);
+  const [workbenchLoadingPath, setWorkbenchLoadingPath] = useState<string | null>(null);
+  const [workbenchShowDiffByPath, setWorkbenchShowDiffByPath] = useState<Record<string, boolean>>({});
+  const [workbenchDiffBaseRefByPath, setWorkbenchDiffBaseRefByPath] = useState<Record<string, string>>({});
+  const [workbenchDiffByPath, setWorkbenchDiffByPath] = useState<
+    Record<string, SessionRuntimeGitDiffResponse | null>
+  >({});
+  const [workbenchDiffErrorByPath, setWorkbenchDiffErrorByPath] = useState<Record<string, string | null>>({});
+  const [workbenchDiffLoadingPath, setWorkbenchDiffLoadingPath] = useState<string | null>(null);
+  const [workbenchGitRootsByPath, setWorkbenchGitRootsByPath] = useState<
+    Record<string, SessionRuntimeGitRoot[]>
+  >({});
+
+  // Stale-request guard. Each async fetch compares against the current session.
+  const sessionIdRef = useRef<string | null>(sessionId);
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
+
+  // Keep a live view of the repo-changes map for fetchRuntimeFiles' refresh loop
+  // without making that callback depend on it (and re-subscribe every change).
+  const repoChangesByRootRef = useRef(repoChangesByRoot);
+  useEffect(() => {
+    repoChangesByRootRef.current = repoChangesByRoot;
+  }, [repoChangesByRoot]);
+
+  const resetWorkbench = useCallback(() => {
+    setRuntimeFiles(null);
+    setRuntimePath('');
+    setRepoChangesByRoot({});
+    setRepoChangesLoadingByRoot({});
+    setExpandedGitDirs({});
+    setWorkbenchTabs([]);
+    setActiveWorkbenchPath(null);
+    setWorkbenchShowDiffByPath({});
+    setWorkbenchDiffByPath({});
+    setWorkbenchDiffErrorByPath({});
+    setWorkbenchDiffBaseRefByPath({});
+    setWorkbenchGitRootsByPath({});
+    setWorkbenchLoadingPath(null);
+    setWorkbenchDiffLoadingPath(null);
+  }, []);
+
+  const bumpRuntimeFilesRefreshKey = useCallback(() => {
+    setRuntimeFilesRefreshKey((current) => current + 1);
+  }, []);
+
+  const fetchChangedFilesForRepo = useCallback(
+    async (path: string): Promise<SessionRuntimeGitChangedFilesResponse | null> => {
+      const sid = sessionIdRef.current;
+      if (!sid) return null;
+      setRepoChangesLoadingByRoot((current) => ({ ...current, [path]: true }));
+      try {
+        const payload = await api.get<SessionRuntimeGitChangedFilesResponse>(
+          `/sessions/${sid}/runtime/git/changed?path=${encodeURIComponent(path)}&limit=200`,
+        );
+        if (sid !== sessionIdRef.current) return null;
+        setRepoChangesByRoot((current) => ({ ...current, [path]: payload }));
+        return payload;
+      } catch {
+        if (sid !== sessionIdRef.current) return null;
+        setRepoChangesByRoot((current) => ({ ...current, [path]: null }));
+        return null;
+      } finally {
+        if (sid === sessionIdRef.current) {
+          setRepoChangesLoadingByRoot((current) => ({ ...current, [path]: false }));
+        }
+      }
+    },
+    [],
+  );
+
+  const fetchRuntimeFiles = useCallback(
+    async (path = '', options?: { refreshGit?: boolean; silent?: boolean }) => {
+      const sid = sessionIdRef.current;
+      if (!sid) return;
+      const silent = Boolean(options?.silent);
+      if (!silent) {
+        setRuntimeFilesLoading(true);
+      }
+      try {
+        const query = new URLSearchParams();
+        if (path.trim().length > 0) query.set('path', path.trim());
+        query.set('limit', '400');
+        const suffix = query.toString();
+        const payload = await api.get<SessionRuntimeFilesResponse>(
+          `/sessions/${sid}/runtime/files${suffix ? `?${suffix}` : ''}`,
+        );
+        if (sid !== sessionIdRef.current) return;
+        setRuntimeFiles(payload);
+        setRuntimePath(payload.path || '');
+        // The caller decides whether to refresh git; SessionsPage gated this on
+        // "files view visible" historically, but the hook is view-agnostic, so
+        // refresh whenever explicitly requested.
+        if (options?.refreshGit) {
+          Object.keys(repoChangesByRootRef.current).forEach((rootPath) => {
+            void fetchChangedFilesForRepo(rootPath);
+          });
+        }
+      } catch (err) {
+        if (sid !== sessionIdRef.current) return;
+        // Directory no longer exists — walk up to the nearest valid parent.
+        if ((err as { status?: number }).status === 404 && path) {
+          const parent = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
+          void fetchRuntimeFiles(parent, options);
+          return;
+        }
+        // Preserve the last successful explorer tree on transient failures.
+      } finally {
+        if (sid === sessionIdRef.current && !silent) {
+          setRuntimeFilesLoading(false);
+        }
+      }
+    },
+    [fetchChangedFilesForRepo],
+  );
+
+  const loadRuntimeDirectoryEntries = useCallback(
+    async (path: string): Promise<SessionRuntimeFileEntry[]> => {
+      const sid = sessionIdRef.current;
+      if (!sid) return [];
+      const query = new URLSearchParams();
+      if (path.trim().length > 0) query.set('path', path.trim());
+      query.set('limit', '400');
+      const suffix = query.toString();
+      const payload = await api.get<SessionRuntimeFilesResponse>(
+        `/sessions/${sid}/runtime/files${suffix ? `?${suffix}` : ''}`,
+      );
+      if (sid !== sessionIdRef.current) return [];
+      return Array.isArray(payload?.entries) ? payload.entries : [];
+    },
+    [],
+  );
+
+  const downloadRuntimeEntry = useCallback(async (entry: SessionRuntimeFileEntry) => {
+    const sid = sessionIdRef.current;
+    if (!sid) return;
+    try {
+      const { blob, filename } = await api.download(
+        `/sessions/${sid}/runtime/download?path=${encodeURIComponent(entry.path)}`,
+        { timeoutMs: 120_000 },
+      );
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = filename || (entry.kind === 'directory' ? `${entry.name}.zip` : entry.name);
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+    } catch {
+      toast.error(entry.kind === 'directory' ? 'Failed to download folder zip' : 'Failed to download file');
+    }
+  }, []);
+
+  const fetchRuntimeGitRoots = useCallback(async (path: string) => {
+    const sid = sessionIdRef.current;
+    if (!sid) return;
+    try {
+      const payload = await api.get<SessionRuntimeGitRootsResponse>(
+        `/sessions/${sid}/runtime/git/roots?path=${encodeURIComponent(path)}&limit=200`,
+      );
+      if (sid !== sessionIdRef.current) return;
+      setWorkbenchGitRootsByPath((current) => ({ ...current, [path]: payload.roots || [] }));
+    } catch {
+      if (sid !== sessionIdRef.current) return;
+      setWorkbenchGitRootsByPath((current) => ({ ...current, [path]: [] }));
+    }
+  }, []);
+
+  const fetchRuntimeGitDiff = useCallback(
+    async (path: string, options?: { baseRef?: string }) => {
+      const sid = sessionIdRef.current;
+      if (!sid) return;
+      const baseRefRaw = options?.baseRef ?? workbenchDiffBaseRefByPath[path];
+      const baseRef =
+        typeof baseRefRaw === 'string' && baseRefRaw.trim().length > 0 ? baseRefRaw.trim() : 'HEAD';
+      setWorkbenchDiffLoadingPath(path);
+      setWorkbenchDiffErrorByPath((current) => ({ ...current, [path]: null }));
+      try {
+        const query = new URLSearchParams();
+        query.set('path', path);
+        query.set('base_ref', baseRef);
+        query.set('staged', 'false');
+        query.set('context_lines', '3');
+        query.set('max_bytes', '120000');
+        const payload = await api.get<SessionRuntimeGitDiffResponse>(
+          `/sessions/${sid}/runtime/git/diff?${query.toString()}`,
+        );
+        if (sid !== sessionIdRef.current) return;
+        setWorkbenchDiffByPath((current) => ({ ...current, [path]: payload }));
+        setWorkbenchShowDiffByPath((current) => ({ ...current, [path]: true }));
+        if (!workbenchGitRootsByPath[path]?.length) {
+          void fetchRuntimeGitRoots(path);
+        }
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : 'Failed to load git diff';
+        setWorkbenchDiffErrorByPath((current) => ({ ...current, [path]: detail }));
+      } finally {
+        if (sid === sessionIdRef.current) {
+          setWorkbenchDiffLoadingPath((current) => (current === path ? null : current));
+        }
+      }
+    },
+    [workbenchDiffBaseRefByPath, workbenchGitRootsByPath, fetchRuntimeGitRoots],
+  );
+
+  const openRuntimeFile = useCallback(
+    async (path: string, options?: { suppressErrorToast?: boolean }): Promise<boolean> => {
+      const sid = sessionIdRef.current;
+      if (!sid) return false;
+      setWorkbenchLoadingPath(path);
+      try {
+        const payload = await api.get<SessionRuntimeFilePreviewResponse>(
+          `/sessions/${sid}/runtime/file?path=${encodeURIComponent(path)}&max_bytes=32000`,
+        );
+        if (sid !== sessionIdRef.current) return false;
+        const nextTab: WorkbenchTab = {
+          path: payload.path,
+          name: payload.name,
+          size_bytes: payload.size_bytes,
+          modified_at: payload.modified_at,
+          content: payload.content,
+          truncated: payload.truncated,
+          max_bytes: payload.max_bytes,
+        };
+        setWorkbenchTabs((current) => {
+          const existing = current.find((tab) => tab.path === nextTab.path);
+          if (existing) {
+            return current.map((tab) => (tab.path === nextTab.path ? nextTab : tab));
+          }
+          return [...current, nextTab];
+        });
+        setActiveWorkbenchPath(nextTab.path);
+        setWorkbenchDiffBaseRefByPath((current) =>
+          current[nextTab.path] ? current : { ...current, [nextTab.path]: 'HEAD' },
+        );
+        setWorkbenchDiffErrorByPath((current) => ({ ...current, [nextTab.path]: null }));
+        setWorkbenchShowDiffByPath((current) =>
+          Object.prototype.hasOwnProperty.call(current, nextTab.path)
+            ? current
+            : { ...current, [nextTab.path]: false },
+        );
+        void fetchRuntimeGitRoots(nextTab.path);
+        return true;
+      } catch {
+        if (!options?.suppressErrorToast) {
+          toast.error('Failed to open runtime file');
+        }
+        return false;
+      } finally {
+        if (sid === sessionIdRef.current) {
+          setWorkbenchLoadingPath((current) => (current === path ? null : current));
+        }
+      }
+    },
+    [fetchRuntimeGitRoots],
+  );
+
+  const ensureWorkbenchTab = useCallback((path: string) => {
+    const name = path.split('/').pop() || path;
+    setWorkbenchTabs((current) => {
+      if (current.some((tab) => tab.path === path)) return current;
+      return [
+        ...current,
+        { path, name, size_bytes: 0, modified_at: null, content: '', truncated: false, max_bytes: 0 },
+      ];
+    });
+    setActiveWorkbenchPath(path);
+    setWorkbenchDiffBaseRefByPath((current) => (current[path] ? current : { ...current, [path]: 'HEAD' }));
+    setWorkbenchDiffErrorByPath((current) => ({ ...current, [path]: null }));
+  }, []);
+
+  const openRuntimeFileDiff = useCallback(
+    async (path: string) => {
+      const sid = sessionIdRef.current;
+      if (!sid) return;
+      const opened = await openRuntimeFile(path, { suppressErrorToast: true });
+      if (!opened) {
+        ensureWorkbenchTab(path);
+      }
+      setWorkbenchShowDiffByPath((current) => ({ ...current, [path]: true }));
+      void fetchRuntimeGitDiff(path);
+    },
+    [openRuntimeFile, ensureWorkbenchTab, fetchRuntimeGitDiff],
+  );
+
+  const openRuntimeDirectory = useCallback(
+    async (path: string, options?: { autoOpenFirstDiff?: boolean }) => {
+      const sid = sessionIdRef.current;
+      if (!sid) return;
+      const shouldAutoOpenFirstDiff = Boolean(options?.autoOpenFirstDiff);
+      await fetchRuntimeFiles(path, { refreshGit: !shouldAutoOpenFirstDiff });
+      if (!shouldAutoOpenFirstDiff) return;
+      const changed = await fetchChangedFilesForRepo(path);
+      const firstPath = changed?.entries?.[0]?.path;
+      if (!firstPath) return;
+      await openRuntimeFileDiff(firstPath);
+    },
+    [fetchRuntimeFiles, fetchChangedFilesForRepo, openRuntimeFileDiff],
+  );
+
+  const closeWorkbenchTab = useCallback((path: string) => {
+    setWorkbenchTabs((current) => {
+      const targetIndex = current.findIndex((tab) => tab.path === path);
+      const next = current.filter((tab) => tab.path !== path);
+      setActiveWorkbenchPath((previous) => {
+        if (previous !== path) return previous;
+        if (!next.length) return null;
+        const fallbackIndex = Math.min(Math.max(targetIndex - 1, 0), next.length - 1);
+        return next[fallbackIndex]?.path ?? next[next.length - 1].path;
+      });
+      return next;
+    });
+    const dropKey = <T,>(record: Record<string, T>): Record<string, T> => {
+      const next = { ...record };
+      delete next[path];
+      return next;
+    };
+    setWorkbenchShowDiffByPath(dropKey);
+    setWorkbenchDiffByPath(dropKey);
+    setWorkbenchDiffErrorByPath(dropKey);
+    setWorkbenchDiffBaseRefByPath(dropKey);
+    setWorkbenchGitRootsByPath(dropKey);
+    setWorkbenchLoadingPath((current) => (current === path ? null : current));
+    setWorkbenchDiffLoadingPath((current) => (current === path ? null : current));
+  }, []);
+
+  const closeAllWorkbenchTabs = useCallback(() => {
+    setWorkbenchTabs([]);
+    setActiveWorkbenchPath(null);
+    setWorkbenchShowDiffByPath({});
+    setWorkbenchDiffByPath({});
+    setWorkbenchDiffErrorByPath({});
+    setWorkbenchDiffBaseRefByPath({});
+    setWorkbenchGitRootsByPath({});
+    setWorkbenchLoadingPath(null);
+    setWorkbenchDiffLoadingPath(null);
+  }, []);
+
+  const setShowDiffForPath = useCallback(
+    (path: string, enabled: boolean) => {
+      setWorkbenchShowDiffByPath((current) => ({ ...current, [path]: enabled }));
+      if (enabled) {
+        void fetchRuntimeGitDiff(path);
+      }
+    },
+    [fetchRuntimeGitDiff],
+  );
+
+  const setDiffBaseRefForPath = useCallback(
+    (path: string, baseRef: string) => {
+      setWorkbenchDiffBaseRefByPath((current) => ({ ...current, [path]: baseRef }));
+      setWorkbenchShowDiffByPath((current) => {
+        if (current[path]) {
+          void fetchRuntimeGitDiff(path, { baseRef });
+        }
+        return current;
+      });
+    },
+    [fetchRuntimeGitDiff],
+  );
+
+  const toggleGitDir = useCallback((path: string) => {
+    setExpandedGitDirs((current) => ({ ...current, [path]: !(current[path] ?? false) }));
+  }, []);
+
+  const forgetRepoRoot = useCallback((path: string) => {
+    setRepoChangesByRoot((current) => {
+      const next = { ...current };
+      delete next[path];
+      return next;
+    });
+    setRepoChangesLoadingByRoot((current) => {
+      const next = { ...current };
+      delete next[path];
+      return next;
+    });
+    setExpandedGitDirs((current) => {
+      const next = { ...current };
+      Object.keys(next).forEach((key) => {
+        if (key === path || key.startsWith(`${path}/`)) delete next[key];
+      });
+      return next;
+    });
+  }, []);
+
+  // Reset all state when the session changes (incl. → null). Matches the
+  // wholesale clear SessionsPage did in its session-change effect.
+  useEffect(() => {
+    resetWorkbench();
+  }, [sessionId, resetWorkbench]);
+
+  const activeWorkbenchTab = useMemo(() => {
+    if (!workbenchTabs.length) return null;
+    if (!activeWorkbenchPath) return workbenchTabs[0];
+    return workbenchTabs.find((tab) => tab.path === activeWorkbenchPath) ?? workbenchTabs[0];
+  }, [workbenchTabs, activeWorkbenchPath]);
+
+  const repoChangeSections = useMemo<WorkbenchRepoChangeSection[]>(
+    () =>
+      Object.entries(repoChangesByRoot).map(([rootPath, payload]) => ({
+        id: rootPath,
+        title:
+          (payload?.git_root || rootPath)
+            .split('/')
+            .filter(Boolean)
+            .pop() || rootPath || 'repo',
+        tree: buildRuntimeGitChangedTree(payload),
+        loading: Boolean(repoChangesLoadingByRoot[rootPath]),
+      })),
+    [repoChangesByRoot, repoChangesLoadingByRoot],
+  );
+
+  const activeWorkbenchDiff = activeWorkbenchTab ? workbenchDiffByPath[activeWorkbenchTab.path] ?? null : null;
+  const activeWorkbenchDiffError = activeWorkbenchTab
+    ? workbenchDiffErrorByPath[activeWorkbenchTab.path] ?? null
+    : null;
+  const activeWorkbenchDiffLoading = workbenchDiffLoadingPath === activeWorkbenchTab?.path;
+  const activeWorkbenchBaseRef = activeWorkbenchTab
+    ? workbenchDiffBaseRefByPath[activeWorkbenchTab.path] ?? 'HEAD'
+    : 'HEAD';
+  const activeWorkbenchBaseRefOptions = useMemo(
+    () =>
+      buildDiffBaseRefOptions(
+        activeWorkbenchTab ? workbenchGitRootsByPath[activeWorkbenchTab.path] ?? [] : [],
+        activeWorkbenchBaseRef,
+      ),
+    [activeWorkbenchTab, workbenchGitRootsByPath, activeWorkbenchBaseRef],
+  );
+
+  return {
+    runtimeFiles,
+    runtimePath,
+    runtimeFilesLoading,
+    runtimeFilesRefreshKey,
+    fetchRuntimeFiles,
+    bumpRuntimeFilesRefreshKey,
+    loadRuntimeDirectoryEntries,
+    downloadRuntimeEntry,
+
+    repoChangeSections,
+    expandedGitDirs,
+    toggleGitDir,
+    fetchChangedFilesForRepo,
+    forgetRepoRoot,
+
+    workbenchTabs,
+    activeWorkbenchPath,
+    setActiveWorkbenchPath,
+    workbenchLoadingPath,
+    activeWorkbenchTab,
+    openRuntimeFile,
+    openRuntimeDirectory,
+    openRuntimeFileDiff,
+    closeWorkbenchTab,
+    closeAllWorkbenchTabs,
+
+    workbenchShowDiffByPath,
+    setShowDiffForPath,
+    activeWorkbenchDiff,
+    activeWorkbenchDiffError,
+    activeWorkbenchDiffLoading,
+    activeWorkbenchBaseRef,
+    setDiffBaseRefForPath,
+    activeWorkbenchBaseRefOptions,
+    fetchRuntimeGitDiff,
+
+    resetWorkbench,
+  };
+}

--- a/apps/frontend/sentinel/src/lib/portal-menu.ts
+++ b/apps/frontend/sentinel/src/lib/portal-menu.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+
+export interface MenuRect {
+  top: number;
+  left: number;
+  /** Width of the trigger, so the menu can size/align relative to it. */
+  triggerWidth: number;
+}
+
+/**
+ * Track the viewport rect of a trigger element while `open`, recomputing on
+ * open and on scroll/resize so a menu portaled to `document.body` (position:
+ * fixed) stays glued to its trigger. Returns null while closed.
+ */
+export function useAnchorRect(
+  triggerRef: React.RefObject<HTMLElement | null>,
+  open: boolean,
+): MenuRect | null {
+  const [rect, setRect] = useState<MenuRect | null>(null);
+
+  const measure = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    setRect({ top: r.bottom, left: r.left, triggerWidth: r.width });
+  }, [triggerRef]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setRect(null);
+      return;
+    }
+    measure();
+    // Capture-phase scroll catches nested scroll containers (e.g. a pane body).
+    window.addEventListener('scroll', measure, true);
+    window.addEventListener('resize', measure);
+    return () => {
+      window.removeEventListener('scroll', measure, true);
+      window.removeEventListener('resize', measure);
+    };
+  }, [open, measure]);
+
+  return rect;
+}
+
+/**
+ * Close `open` when a pointer goes down outside both the trigger and the
+ * portaled menu. Both refs are checked because the menu lives in document.body,
+ * outside the trigger's DOM subtree.
+ */
+export function useDismissOnOutside(
+  open: boolean,
+  setOpen: (value: boolean) => void,
+  triggerRef: React.RefObject<HTMLElement | null>,
+  menuRef: React.RefObject<HTMLElement | null>,
+) {
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (menuRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open, setOpen, triggerRef, menuRef]);
+}

--- a/apps/frontend/sentinel/src/lib/session-stream.ts
+++ b/apps/frontend/sentinel/src/lib/session-stream.ts
@@ -1,0 +1,260 @@
+import { wsSessionsBaseUrl } from './env';
+import type { WsConnectionState, WsEvent } from '../types/api';
+
+/**
+ * Shared session WebSocket stream manager
+ * ---------------------------------------
+ * A single, ref-counted WebSocket per (instanceName, sessionId). Every consumer
+ * — the chat stream in SessionsPage, the runtime hooks, and future standalone
+ * runtime tabs — subscribes to the SAME connection through {@link subscribeSessionStream}.
+ * The socket opens on the first subscriber and closes after the last one leaves,
+ * so opening Desktop + Terminal + Files panes for one session still uses ONE
+ * socket rather than three.
+ *
+ * Behavior mirrors the previous inline SessionsPage WS exactly:
+ *   - connection states: connecting → connected, reconnecting on retry;
+ *   - reconnect uses exponential backoff (2^attempt seconds, capped at 20s) and
+ *     gives up after 8 attempts, invoking the registered `onReconnectFailed`;
+ *   - a generation counter drops events from stale sockets after a reconnect.
+ *
+ * Parsed `WsEvent`s are fanned out to event listeners; connection-state changes
+ * to state listeners. Listeners are plain callbacks so React and non-React code
+ * can both consume the stream; the `useSessionStream` hook wraps this for React.
+ */
+
+export type SessionStreamEventListener = (event: WsEvent) => void;
+export type SessionStreamStateListener = (state: WsConnectionState) => void;
+export type SessionStreamReconnectFailedListener = () => void;
+
+interface StreamEntry {
+  key: string;
+  instanceName: string;
+  sessionId: string;
+  ws: WebSocket | null;
+  /** Increment on every (re)connect attempt; events from older sockets are dropped. */
+  generation: number;
+  connection: WsConnectionState;
+  reconnectAttempts: number;
+  reconnectTimer: number | null;
+  intentionalClose: boolean;
+  eventListeners: Set<SessionStreamEventListener>;
+  stateListeners: Set<SessionStreamStateListener>;
+  reconnectFailedListeners: Set<SessionStreamReconnectFailedListener>;
+}
+
+const RECONNECT_MAX_ATTEMPTS = 8;
+const RECONNECT_MAX_DELAY_SECONDS = 20;
+
+const entries = new Map<string, StreamEntry>();
+
+function streamKey(instanceName: string, sessionId: string): string {
+  return `${instanceName}::${sessionId}`;
+}
+
+function setConnection(entry: StreamEntry, state: WsConnectionState): void {
+  if (entry.connection === state) return;
+  entry.connection = state;
+  for (const listener of entry.stateListeners) {
+    listener(state);
+  }
+}
+
+function emitEvent(entry: StreamEntry, event: WsEvent): void {
+  for (const listener of entry.eventListeners) {
+    listener(event);
+  }
+}
+
+function clearReconnectTimer(entry: StreamEntry): void {
+  if (entry.reconnectTimer !== null) {
+    window.clearTimeout(entry.reconnectTimer);
+    entry.reconnectTimer = null;
+  }
+}
+
+function teardownSocket(entry: StreamEntry): void {
+  if (entry.ws) {
+    entry.ws.onopen = null;
+    entry.ws.onmessage = null;
+    entry.ws.onclose = null;
+    entry.ws.onerror = null;
+    try {
+      entry.ws.close();
+    } catch {
+      /* socket may already be closing */
+    }
+    entry.ws = null;
+  }
+}
+
+function scheduleReconnect(entry: StreamEntry): void {
+  entry.reconnectAttempts += 1;
+  if (entry.reconnectAttempts > RECONNECT_MAX_ATTEMPTS) {
+    for (const listener of entry.reconnectFailedListeners) {
+      listener();
+    }
+    return;
+  }
+  const delaySeconds = Math.min(2 ** entry.reconnectAttempts, RECONNECT_MAX_DELAY_SECONDS);
+  entry.reconnectTimer = window.setTimeout(() => {
+    entry.reconnectTimer = null;
+    connect(entry);
+  }, delaySeconds * 1000);
+}
+
+function connect(entry: StreamEntry): void {
+  // Tear down any prior socket without firing reconnect.
+  entry.intentionalClose = true;
+  clearReconnectTimer(entry);
+  teardownSocket(entry);
+  entry.intentionalClose = false;
+
+  setConnection(entry, entry.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
+
+  const generation = ++entry.generation;
+  const ws = new WebSocket(
+    `${wsSessionsBaseUrl(entry.instanceName)}/${entry.sessionId}/stream`,
+  );
+  entry.ws = ws;
+
+  ws.onopen = () => {
+    if (generation !== entry.generation || ws !== entry.ws) return;
+    entry.reconnectAttempts = 0;
+    setConnection(entry, 'connected');
+  };
+
+  ws.onmessage = (messageEvent) => {
+    if (generation !== entry.generation || ws !== entry.ws) return;
+    try {
+      const payload = JSON.parse(messageEvent.data) as WsEvent;
+      emitEvent(entry, payload);
+    } catch {
+      /* ignore malformed frames */
+    }
+  };
+
+  ws.onclose = () => {
+    if (generation !== entry.generation || ws !== entry.ws) return;
+    entry.ws = null;
+    if (!entry.intentionalClose) {
+      scheduleReconnect(entry);
+    }
+  };
+}
+
+function disposeEntry(entry: StreamEntry): void {
+  entry.intentionalClose = true;
+  entry.generation += 1;
+  clearReconnectTimer(entry);
+  teardownSocket(entry);
+  setConnection(entry, 'disconnected');
+  entries.delete(entry.key);
+}
+
+export interface SessionStreamSubscription {
+  /** Current connection state at subscription time (re-read via `onState`). */
+  readonly connection: WsConnectionState;
+  /** Detach this subscriber; closes the socket once the last subscriber leaves. */
+  unsubscribe: () => void;
+}
+
+export interface SessionStreamHandlers {
+  onEvent?: SessionStreamEventListener;
+  onState?: SessionStreamStateListener;
+  /** Fired once when reconnect attempts are exhausted (mirrors the old toast). */
+  onReconnectFailed?: SessionStreamReconnectFailedListener;
+}
+
+/**
+ * Subscribe to the shared stream for a session. Opens the socket on the first
+ * subscriber; closes it when the last subscriber unsubscribes. Returns the
+ * current connection state plus an `unsubscribe` disposer.
+ */
+export function subscribeSessionStream(
+  instanceName: string,
+  sessionId: string,
+  handlers: SessionStreamHandlers,
+): SessionStreamSubscription {
+  const key = streamKey(instanceName, sessionId);
+  let entry = entries.get(key);
+  const isFirstSubscriber = !entry;
+  if (!entry) {
+    entry = {
+      key,
+      instanceName,
+      sessionId,
+      ws: null,
+      generation: 0,
+      connection: 'disconnected',
+      reconnectAttempts: 0,
+      reconnectTimer: null,
+      intentionalClose: false,
+      eventListeners: new Set(),
+      stateListeners: new Set(),
+      reconnectFailedListeners: new Set(),
+    };
+    entries.set(key, entry);
+  }
+
+  if (handlers.onEvent) entry.eventListeners.add(handlers.onEvent);
+  if (handlers.onState) entry.stateListeners.add(handlers.onState);
+  if (handlers.onReconnectFailed) entry.reconnectFailedListeners.add(handlers.onReconnectFailed);
+
+  if (isFirstSubscriber) {
+    connect(entry);
+  } else if (handlers.onState) {
+    // Bring a late subscriber in sync with the live connection state.
+    handlers.onState(entry.connection);
+  }
+
+  const activeEntry = entry;
+  return {
+    get connection() {
+      return activeEntry.connection;
+    },
+    unsubscribe: () => {
+      if (handlers.onEvent) activeEntry.eventListeners.delete(handlers.onEvent);
+      if (handlers.onState) activeEntry.stateListeners.delete(handlers.onState);
+      if (handlers.onReconnectFailed) {
+        activeEntry.reconnectFailedListeners.delete(handlers.onReconnectFailed);
+      }
+      const hasSubscribers =
+        activeEntry.eventListeners.size > 0 ||
+        activeEntry.stateListeners.size > 0 ||
+        activeEntry.reconnectFailedListeners.size > 0;
+      if (!hasSubscribers) {
+        disposeEntry(activeEntry);
+      }
+    },
+  };
+}
+
+/** Non-reactive read of a session's current connection state. */
+export function getSessionStreamConnection(
+  instanceName: string,
+  sessionId: string,
+): WsConnectionState {
+  return entries.get(streamKey(instanceName, sessionId))?.connection ?? 'disconnected';
+}
+
+/** Whether the shared socket for a session is currently OPEN and writable. */
+export function isSessionStreamOpen(instanceName: string, sessionId: string): boolean {
+  const entry = entries.get(streamKey(instanceName, sessionId));
+  return entry?.ws?.readyState === WebSocket.OPEN;
+}
+
+/**
+ * Send a JSON payload over the shared socket for a session. Returns true if the
+ * socket was OPEN and the frame was written, false otherwise (caller decides
+ * how to surface a closed connection).
+ */
+export function sendSessionStreamMessage(
+  instanceName: string,
+  sessionId: string,
+  payload: unknown,
+): boolean {
+  const entry = entries.get(streamKey(instanceName, sessionId));
+  if (entry?.ws?.readyState !== WebSocket.OPEN) return false;
+  entry.ws.send(typeof payload === 'string' ? payload : JSON.stringify(payload));
+  return true;
+}

--- a/apps/frontend/sentinel/src/lib/workspace-context.tsx
+++ b/apps/frontend/sentinel/src/lib/workspace-context.tsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, PropsWithChildren } from 'react';
+import { useParams } from 'react-router-dom';
+
+export interface WorkspaceContextValue {
+  /** The instance the surrounding pane is scoped to. */
+  instanceName: string | undefined;
+  /** True when this subtree is rendered inside a tiling workspace pane. */
+  workspaceMode: boolean;
+}
+
+const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
+
+export interface WorkspaceProviderProps extends PropsWithChildren {
+  instanceName: string | undefined;
+  workspaceMode?: boolean;
+}
+
+/**
+ * Provides the instance scope to page components rendered inside a workspace
+ * pane. Panes are not the active route, so they cannot rely on `useParams`.
+ */
+export function WorkspaceProvider({
+  instanceName,
+  workspaceMode = true,
+  children,
+}: WorkspaceProviderProps) {
+  return (
+    <WorkspaceContext.Provider value={{ instanceName, workspaceMode }}>
+      {children}
+    </WorkspaceContext.Provider>
+  );
+}
+
+/** Raw context access; null when rendered outside a workspace pane. */
+export function useWorkspaceContext(): WorkspaceContextValue | null {
+  return useContext(WorkspaceContext);
+}
+
+/**
+ * Returns the instance name from the surrounding workspace pane when present,
+ * otherwise falls back to the active route's `:instanceName` param. Page
+ * components should use this instead of reading `useParams` directly so they
+ * render correctly both as a route and inside a pane.
+ */
+export function useInstanceName(): string | undefined {
+  const ctx = useContext(WorkspaceContext);
+  const params = useParams<{ instanceName?: string }>();
+  if (ctx) {
+    return ctx.instanceName;
+  }
+  return params.instanceName;
+}
+
+/** True when the current subtree is rendered inside a tiling workspace pane. */
+export function useWorkspaceMode(): boolean {
+  const ctx = useContext(WorkspaceContext);
+  return ctx?.workspaceMode ?? false;
+}

--- a/apps/frontend/sentinel/src/lib/workspace-tabs.tsx
+++ b/apps/frontend/sentinel/src/lib/workspace-tabs.tsx
@@ -9,6 +9,9 @@ import {
   GitBranch,
   Send,
   Settings,
+  Terminal,
+  Globe,
+  Folder,
   type LucideIcon,
 } from 'lucide-react';
 import { ComponentType } from 'react';
@@ -21,6 +24,9 @@ import { ModulesPage } from '../pages/ModulesPage';
 import { GitPage } from '../pages/GitPage';
 import { TelegramPage } from '../pages/TelegramPage';
 import { SettingsPage } from '../pages/SettingsPage';
+import { TerminalTab } from '../components/workspace/TerminalTab';
+import { DesktopTab } from '../components/workspace/tabs/DesktopTab';
+import { FilesTab } from '../pages/FilesTab';
 
 // approvals/permissions reuse ModulesPage but need their section passed
 // explicitly, since a pane is not the active route (no section in the URL).
@@ -31,6 +37,9 @@ const PermissionsTab = () => <ModulesPage section="permissions" />;
 /** Stable identifier for each workspace tab. Persisted into the layout. */
 export type WorkspaceTabId =
   | 'sessions'
+  | 'desktop'
+  | 'terminal'
+  | 'files'
   | 'logs'
   | 'memory'
   | 'triggers'
@@ -55,6 +64,9 @@ export interface WorkspaceTab {
  */
 export const WORKSPACE_TABS: WorkspaceTab[] = [
   { id: 'sessions', label: 'Sessions', icon: LayoutDashboard, component: SessionsPage },
+  { id: 'desktop', label: 'Desktop', icon: Globe, component: DesktopTab },
+  { id: 'terminal', label: 'Terminal', icon: Terminal, component: TerminalTab },
+  { id: 'files', label: 'Files', icon: Folder, component: FilesTab },
   { id: 'logs', label: 'Session Logs', icon: Activity, component: LogsPage },
   { id: 'memory', label: 'Memory', icon: Database, component: MemoryPage },
   { id: 'triggers', label: 'Triggers', icon: Zap, component: TriggersPage },

--- a/apps/frontend/sentinel/src/lib/workspace-tabs.tsx
+++ b/apps/frontend/sentinel/src/lib/workspace-tabs.tsx
@@ -1,0 +1,90 @@
+import {
+  LayoutDashboard,
+  Activity,
+  Database,
+  Zap,
+  LayoutGrid,
+  CheckCircle,
+  Lock,
+  GitBranch,
+  Send,
+  Settings,
+  type LucideIcon,
+} from 'lucide-react';
+import { ComponentType } from 'react';
+
+import { SessionsPage } from '../pages/SessionsPage';
+import { LogsPage } from '../pages/LogsPage';
+import { MemoryPage } from '../pages/MemoryPage';
+import { TriggersPage } from '../pages/TriggersPage';
+import { ModulesPage } from '../pages/ModulesPage';
+import { GitPage } from '../pages/GitPage';
+import { TelegramPage } from '../pages/TelegramPage';
+import { SettingsPage } from '../pages/SettingsPage';
+
+// approvals/permissions reuse ModulesPage but need their section passed
+// explicitly, since a pane is not the active route (no section in the URL).
+const ModulesTab = () => <ModulesPage section="modules" />;
+const ApprovalsTab = () => <ModulesPage section="approvals" />;
+const PermissionsTab = () => <ModulesPage section="permissions" />;
+
+/** Stable identifier for each workspace tab. Persisted into the layout. */
+export type WorkspaceTabId =
+  | 'sessions'
+  | 'logs'
+  | 'memory'
+  | 'triggers'
+  | 'modules'
+  | 'approvals'
+  | 'permissions'
+  | 'git'
+  | 'telegram'
+  | 'settings';
+
+export interface WorkspaceTab {
+  id: WorkspaceTabId;
+  label: string;
+  icon: LucideIcon;
+  component: ComponentType;
+}
+
+/**
+ * Every left-tab option that can be hosted inside a workspace pane. Labels and
+ * icons mirror the AppShell sidebar nav. `approvals` and `permissions` reuse
+ * ModulesPage but remain distinct tabs (each open at most once).
+ */
+export const WORKSPACE_TABS: WorkspaceTab[] = [
+  { id: 'sessions', label: 'Sessions', icon: LayoutDashboard, component: SessionsPage },
+  { id: 'logs', label: 'Session Logs', icon: Activity, component: LogsPage },
+  { id: 'memory', label: 'Memory', icon: Database, component: MemoryPage },
+  { id: 'triggers', label: 'Triggers', icon: Zap, component: TriggersPage },
+  { id: 'modules', label: 'Modules', icon: LayoutGrid, component: ModulesTab },
+  { id: 'approvals', label: 'Approvals', icon: CheckCircle, component: ApprovalsTab },
+  { id: 'permissions', label: 'Permissions', icon: Lock, component: PermissionsTab },
+  { id: 'git', label: 'Git', icon: GitBranch, component: GitPage },
+  { id: 'telegram', label: 'Telegram', icon: Send, component: TelegramPage },
+  { id: 'settings', label: 'Settings', icon: Settings, component: SettingsPage },
+];
+
+/** Lookup map keyed by tab id for O(1) access from the workspace store. */
+export const WORKSPACE_TABS_BY_ID: Record<WorkspaceTabId, WorkspaceTab> =
+  WORKSPACE_TABS.reduce(
+    (acc, tab) => {
+      acc[tab.id] = tab;
+      return acc;
+    },
+    {} as Record<WorkspaceTabId, WorkspaceTab>,
+  );
+
+/** Ordered list of every valid tab id. */
+export const WORKSPACE_TAB_IDS: WorkspaceTabId[] = WORKSPACE_TABS.map((t) => t.id);
+
+/** Type guard: is the given string a known workspace tab id. */
+export function isWorkspaceTabId(value: string): value is WorkspaceTabId {
+  return value in WORKSPACE_TABS_BY_ID;
+}
+
+/** Resolve a tab id to its registry entry (undefined when unknown). */
+export function getWorkspaceTab(id: string): WorkspaceTab | undefined {
+  return WORKSPACE_TABS_BY_ID[id as WorkspaceTabId];
+}

--- a/apps/frontend/sentinel/src/pages/AdminPage.tsx
+++ b/apps/frontend/sentinel/src/pages/AdminPage.tsx
@@ -77,8 +77,8 @@ export function AdminPage() {
       subtitle="Critical Overrides & Audit Protocol"
       actions={
         <div className="flex items-center gap-2">
-          <button onClick={() => void loadAdminData(true)} className="p-2 text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)] transition-all active:scale-95">
-            <RefreshCw size={18} className={loading ? 'animate-spin' : ''} />
+          <button onClick={() => void loadAdminData(true)} aria-label="Refresh" className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm">
+            <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
           </button>
         </div>
       }    >

--- a/apps/frontend/sentinel/src/pages/FilesTab.tsx
+++ b/apps/frontend/sentinel/src/pages/FilesTab.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { FolderTree } from 'lucide-react';
+
+import { Workbench } from '../components/workbench/Workbench';
+import { useInstanceName } from '../lib/workspace-context';
+import { useActiveSessionId } from '../store/active-session-store';
+import { useSessionRuntimeStream } from '../hooks/useSessionRuntimeStream';
+import { useSessionWorkbench } from '../hooks/useSessionWorkbench';
+import type { SessionRuntimeFileEntry } from '../types/api';
+
+/**
+ * Standalone FILES workspace tab.
+ *
+ * Hosts the FULL file workbench for the workspace-wide active session:
+ *   - directory browser (WorkbenchExplorerPane via Workbench's `showExplorer`);
+ *   - open-file → VIEW contents;
+ *   - git DIFF view (with base-ref selection);
+ *   - repo-changes sections + expand/collapse;
+ *   - file/folder download.
+ *
+ * All file/git logic lives in {@link useSessionWorkbench}; this component only
+ * wires the hook to the {@link Workbench} surface and drives the same
+ * fetch/refresh lifecycle SessionsPage's files view used. It subscribes to the
+ * shared, ref-counted session stream purely to know when the runtime is
+ * `connected` so the live 3s refresh loop matches the original behavior — that
+ * subscription reuses the single socket already opened for the session.
+ */
+export function FilesTab() {
+  const instanceName = useInstanceName() ?? null;
+  const activeSessionId = useActiveSessionId();
+
+  const {
+    runtimeFiles,
+    runtimePath,
+    runtimeFilesLoading,
+    runtimeFilesRefreshKey,
+    fetchRuntimeFiles,
+    loadRuntimeDirectoryEntries,
+    downloadRuntimeEntry,
+
+    repoChangeSections,
+    expandedGitDirs,
+    toggleGitDir,
+    fetchChangedFilesForRepo,
+    forgetRepoRoot,
+
+    workbenchTabs,
+    activeWorkbenchPath,
+    setActiveWorkbenchPath,
+    activeWorkbenchTab,
+    openRuntimeFile,
+    openRuntimeFileDiff,
+    closeWorkbenchTab,
+    closeAllWorkbenchTabs,
+
+    workbenchShowDiffByPath,
+    setShowDiffForPath,
+    activeWorkbenchDiff,
+    activeWorkbenchDiffError,
+    activeWorkbenchDiffLoading,
+    activeWorkbenchBaseRef,
+    setDiffBaseRefForPath,
+    activeWorkbenchBaseRefOptions,
+  } = useSessionWorkbench(activeSessionId);
+
+  // Subscribe to the shared session stream so we know when the runtime is
+  // connected (gates the live refresh loop). Ref-counted: this reuses the same
+  // socket SessionsPage / Desktop / Terminal already opened for this session.
+  const { connection } = useSessionRuntimeStream(instanceName, activeSessionId);
+
+  // Workbench sizes itself off an explicit pixel `width`. Inside a flexible
+  // workspace pane we measure the host so the workbench fills it (down to its
+  // own 400px min-width) and tracks pane resizes.
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [hostWidth, setHostWidth] = useState(0);
+  useLayoutEffect(() => {
+    const node = hostRef.current;
+    if (!node) return;
+    setHostWidth(node.clientWidth);
+    const observer = new ResizeObserver((entries) => {
+      const next = entries[0]?.contentRect.width;
+      if (typeof next === 'number') setHostWidth(next);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [activeSessionId]);
+
+  // Initial + on-session-change load. Mirrors SessionsPage's files-view fetch
+  // (refreshGit so repo-changes sections populate alongside the tree).
+  useEffect(() => {
+    if (!activeSessionId) return;
+    void fetchRuntimeFiles('', { refreshGit: true, silent: false });
+  }, [activeSessionId, fetchRuntimeFiles]);
+
+  // Live refresh loop: while connected, silently re-fetch the current dir +
+  // repo changes every 3s. Matches the original files-view polling exactly.
+  useEffect(() => {
+    if (!activeSessionId) return;
+    if (connection !== 'connected') return;
+    const timer = window.setInterval(() => {
+      void fetchRuntimeFiles(runtimePath, { refreshGit: true, silent: true });
+    }, 3000);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [activeSessionId, connection, runtimePath, fetchRuntimeFiles]);
+
+  const handleExplorerDirectoryToggle = useCallback(
+    (entry: SessionRuntimeFileEntry, expanded: boolean) => {
+      if (!activeSessionId || !entry.is_git_root) return;
+      if (!expanded) {
+        forgetRepoRoot(entry.path);
+        return;
+      }
+      void fetchChangedFilesForRepo(entry.path);
+    },
+    [activeSessionId, forgetRepoRoot, fetchChangedFilesForRepo],
+  );
+
+  if (!activeSessionId) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-12 text-center text-[color:var(--text-muted)]">
+        <div className="flex h-16 w-16 items-center justify-center rounded-3xl bg-[color:var(--surface-2)]">
+          <FolderTree size={32} strokeWidth={1} />
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-[13px] font-bold uppercase tracking-widest text-[color:var(--text-primary)]">
+            Files
+          </h3>
+          <p className="max-w-[240px] text-[11px] leading-relaxed opacity-70">
+            Select a session to browse its runtime files, view contents, and inspect git diffs.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={hostRef} className="flex h-full w-full min-h-0 overflow-hidden">
+      <Workbench
+        className="h-full flex-1 border-l-0"
+        width={hostWidth}
+        tabs={workbenchTabs}
+        activeTabPath={activeWorkbenchPath}
+        onTabClick={(path) => setActiveWorkbenchPath(path)}
+        onTabClose={closeWorkbenchTab}
+        onCloseAll={closeAllWorkbenchTabs}
+        showExplorer
+        explorerEntries={runtimeFiles?.entries || []}
+        currentExplorerPath={runtimePath}
+        explorerLoading={runtimeFilesLoading}
+        onExplorerFileClick={(entry) => void openRuntimeFile(entry.path)}
+        onExplorerDownload={(entry) => void downloadRuntimeEntry(entry)}
+        loadExplorerDirectory={loadRuntimeDirectoryEntries}
+        explorerRefreshKey={runtimeFilesRefreshKey}
+        onExplorerDirectoryToggle={handleExplorerDirectoryToggle}
+        repoChangesSections={repoChangeSections}
+        expandedGitDirs={expandedGitDirs}
+        onToggleGitDir={toggleGitDir}
+        onGitFileClick={(path) => void openRuntimeFileDiff(path)}
+        diffMode={activeWorkbenchTab ? workbenchShowDiffByPath[activeWorkbenchTab.path] ?? false : false}
+        setDiffMode={(enabled) => {
+          if (!activeWorkbenchTab) return;
+          setShowDiffForPath(activeWorkbenchTab.path, enabled);
+        }}
+        diffContent={activeWorkbenchDiff}
+        diffLoading={activeWorkbenchDiffLoading}
+        diffError={activeWorkbenchDiffError}
+        diffBaseRef={activeWorkbenchBaseRef}
+        onDiffBaseRefChange={(ref) => {
+          if (!activeWorkbenchTab) return;
+          setDiffBaseRefForPath(activeWorkbenchTab.path, ref);
+        }}
+        diffBaseRefOptions={activeWorkbenchBaseRefOptions}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/sentinel/src/pages/GitPage.tsx
+++ b/apps/frontend/sentinel/src/pages/GitPage.tsx
@@ -195,10 +195,10 @@ export function GitPage() {
       actions={(
         <button
           onClick={() => void refreshAll()}
-          className="p-2 text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)] transition-all active:scale-95"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
           aria-label="Refresh"
         >
-          <RefreshCw size={18} className={refreshing ? 'animate-spin' : ''} />
+          <RefreshCw size={14} className={refreshing ? 'animate-spin' : ''} />
         </button>
       )}    >
       <div className="max-w-3xl mx-auto space-y-6">

--- a/apps/frontend/sentinel/src/pages/GitPage.tsx
+++ b/apps/frontend/sentinel/src/pages/GitPage.tsx
@@ -13,6 +13,7 @@ import { Panel } from '../components/ui/Panel';
 import { StatusChip } from '../components/ui/StatusChip';
 import { api } from '../lib/api';
 import { formatCompactDate } from '../lib/format';
+import { useWorkspaceMode } from '../lib/workspace-context';
 import { instanceRouteFromPath } from '../lib/routes';
 import { useAuthStore } from '../store/auth-store';
 import type {
@@ -42,6 +43,7 @@ const EMPTY_FORM: GitAccountForm = {
 
 export function GitPage() {
   const location = useLocation();
+  const workspaceMode = useWorkspaceMode();
   const role = useAuthStore((state) => state.role);
   const [accounts, setAccounts] = useState<GitAccount[]>([]);
   const [loading, setLoading] = useState(true);
@@ -69,6 +71,17 @@ export function GitPage() {
   }, [loadAll]);
 
   if (role !== 'admin') {
+    // Inside a tiling pane the page is not the active route, so a redirect would
+    // hijack the global URL and unmount sibling panes. Show an inline notice.
+    if (workspaceMode) {
+      return (
+        <AppShell title="Git" subtitle="Source Control">
+          <Panel className="p-6 text-sm text-[color:var(--text-secondary)]">
+            Git account management is available to administrators only.
+          </Panel>
+        </AppShell>
+      );
+    }
     return <Navigate to={instanceRouteFromPath(location.pathname, 'settings')} replace />;
   }
 

--- a/apps/frontend/sentinel/src/pages/InstancePickerPage.tsx
+++ b/apps/frontend/sentinel/src/pages/InstancePickerPage.tsx
@@ -101,7 +101,7 @@ export function InstancePickerPage() {
   }, [renamingName]);
 
   const openInstance = (instanceName: string) => {
-    navigate(`/instances/${encodeURIComponent(instanceName)}/sessions`);
+    navigate(`/instances/${encodeURIComponent(instanceName)}/workspace`);
   };
 
   const createInstance = async (event: FormEvent) => {

--- a/apps/frontend/sentinel/src/pages/LogsPage.tsx
+++ b/apps/frontend/sentinel/src/pages/LogsPage.tsx
@@ -2083,14 +2083,14 @@ export function LogsPage() {
                   session: activeSession,
                   context: latestRuntimeContext
                 })}
-                className="inline-flex h-9 items-center gap-2.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
+                className="inline-flex h-7 items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-3 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
               >
                 <Cpu size={14} className="text-sky-500/80" />
                 Latest Snapshot
               </button>
               <button
                 onClick={() => setRuntimeExplorerOpen(true)}
-                className="inline-flex h-9 items-center gap-2.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
+                className="inline-flex h-7 items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-3 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
               >
                 <Terminal size={14} className="text-amber-500/80" />
                 Runtime Info

--- a/apps/frontend/sentinel/src/pages/MemoryPage.tsx
+++ b/apps/frontend/sentinel/src/pages/MemoryPage.tsx
@@ -342,15 +342,14 @@ export function MemoryPage() {
       contentClassName="h-full !p-0 overflow-hidden"
       actions={
         <div className="flex items-center gap-2">
-          <button onClick={() => void refreshAll()} className="p-2 text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)] transition-colors active:scale-95">
-            <RefreshCw size={18} className={loadingRoots ? 'animate-spin' : ''} />
+          <button onClick={() => void refreshAll()} aria-label="Refresh" className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm">
+            <RefreshCw size={14} className={loadingRoots ? 'animate-spin' : ''} />
           </button>
-          <div className="h-4 w-px bg-[color:var(--border-subtle)] mx-1" />
           <button
            onClick={() => openEditor(null)}
-           className="inline-flex h-9 items-center gap-2.5 rounded-full border border-transparent bg-[color:var(--accent-solid)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--app-bg)] transition-all hover:opacity-90 active:scale-95 shadow-md shadow-black/5"
+           className="inline-flex h-7 items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-3 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
          >
-            <Plus size={14} />
+            <Plus size={14} className="text-emerald-500/80" />
             Add Memory
           </button>
         </div>

--- a/apps/frontend/sentinel/src/pages/ModulesPage.tsx
+++ b/apps/frontend/sentinel/src/pages/ModulesPage.tsx
@@ -1773,12 +1773,16 @@ const SECTION_LABELS: Record<ModuleSection, string> = {
   permissions: 'Permissions',
 };
 
-export function ModulesPage() {
+export function ModulesPage({ section }: { section?: ModuleSection } = {}) {
   const location = useLocation();
-  let activeSection: ModuleSection = 'modules';
-  const sectionPath = location.pathname.replace(/^\/instances\/[^/]+/, '');
-  if (sectionPath.startsWith('/approvals')) activeSection = 'approvals';
-  else if (sectionPath.startsWith('/permissions')) activeSection = 'permissions';
+  // Workspace panes pass `section` explicitly (a pane is not the active route).
+  // Outside a pane the section is derived from the URL.
+  let activeSection: ModuleSection = section ?? 'modules';
+  if (!section) {
+    const sectionPath = location.pathname.replace(/^\/instances\/[^/]+/, '');
+    if (sectionPath.startsWith('/approvals')) activeSection = 'approvals';
+    else if (sectionPath.startsWith('/permissions')) activeSection = 'permissions';
+  }
 
   const isFullHeight = activeSection === 'modules';
 

--- a/apps/frontend/sentinel/src/pages/SessionsPage.tsx
+++ b/apps/frontend/sentinel/src/pages/SessionsPage.tsx
@@ -2,8 +2,6 @@ import {
   ArrowDown,
   Bot,
   ChevronDown,
-  Home,
-  Expand,
   Loader2,
   Plus,
   RefreshCw,
@@ -51,6 +49,7 @@ import {
 } from '../lib/approvals';
 import { api } from '../lib/api';
 import { useInstanceName, useWorkspaceMode } from '../lib/workspace-context';
+import { useAnchorRect } from '../lib/portal-menu';
 import { instanceRouteFromPath } from '../lib/routes';
 import { getSessionDeleteWorkspaceSummary } from '../lib/sessionDeletion';
 import { useSetActiveSession } from '../store/active-session-store';
@@ -737,7 +736,9 @@ export function SessionsPage() {
       if (sessionDropdownRef.current?.contains(target)) return;
       if (sessionDropdownMenuRef.current?.contains(target)) return;
       if (effortDropdownRef.current?.contains(target)) return;
+      if (effortDropdownMenuRef.current?.contains(target)) return;
       if (agentModeDropdownRef.current?.contains(target)) return;
+      if (agentModeDropdownMenuRef.current?.contains(target)) return;
       setIsSessionDropdownOpen(false);
       setIsEffortDropdownOpen(false);
       setIsAgentModeDropdownOpen(false);
@@ -774,6 +775,7 @@ export function SessionsPage() {
   const [isStopping, setIsStopping] = useState(false);
   const [rightPanelWidth, setRightPanelWidth] = useState(400);
   const [isResizing, setIsResizing] = useState(false);
+  const [statusTooltip, setStatusTooltip] = useState<'connection' | 'progress' | 'context' | null>(null);
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const messagesRef = useRef<Message[]>([]);
@@ -793,10 +795,20 @@ export function SessionsPage() {
   const sessionDropdownButtonRef = useRef<HTMLButtonElement | null>(null);
   const sessionDropdownMenuRef = useRef<HTMLDivElement | null>(null);
   const effortDropdownRef = useRef<HTMLDivElement | null>(null);
+  const effortDropdownMenuRef = useRef<HTMLDivElement | null>(null);
   const agentModeDropdownRef = useRef<HTMLDivElement | null>(null);
+  const agentModeDropdownMenuRef = useRef<HTMLDivElement | null>(null);
+  const connectionPillRef = useRef<HTMLDivElement | null>(null);
+  const progressPillRef = useRef<HTMLDivElement | null>(null);
+  const contextPillRef = useRef<HTMLDivElement | null>(null);
   const activeSessionIdRef = useRef<string | null>(routeSessionId ?? null);
   const contextUsageRequestRef = useRef(0);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
+  const effortDropdownRect = useAnchorRect(effortDropdownRef, isEffortDropdownOpen);
+  const agentModeDropdownRect = useAnchorRect(agentModeDropdownRef, isAgentModeDropdownOpen);
+  const connectionTooltipRect = useAnchorRect(connectionPillRef, statusTooltip === 'connection');
+  const progressTooltipRect = useAnchorRect(progressPillRef, statusTooltip === 'progress');
+  const contextTooltipRect = useAnchorRect(contextPillRef, statusTooltip === 'context');
 
   // Keep refs in sync so WS callbacks can read current values
   useEffect(() => { activeSessionIdRef.current = activeSessionId; }, [activeSessionId]);
@@ -2494,186 +2506,81 @@ export function SessionsPage() {
           hideHeader={mode === 'solo'}
           actions={
             mode === 'advanced' ? (
-              <div className="flex min-w-0 items-center gap-2">
-                <div ref={sessionDropdownRef} className="order-5 relative z-[200] hidden min-w-0 sm:block">
-                  <button
-                    ref={sessionDropdownButtonRef}
-                    type="button"
-                    aria-haspopup="listbox"
-                    aria-expanded={isSessionDropdownOpen}
-                    onClick={() => {
-                      setIsEffortDropdownOpen(false);
-                      setIsAgentModeDropdownOpen(false);
-                      updateSessionDropdownRect();
-                      setIsSessionDropdownOpen((open) => !open);
-                    }}
-                    className="flex h-9 w-[min(390px,34vw)] items-center justify-start gap-4 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] pl-4 pr-3 text-left shadow-sm outline-none transition-all hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface-2)] focus:border-[color:var(--accent-solid)] focus:ring-2 focus:ring-[color:var(--accent-solid)]/20"
+              <div className="flex w-full min-w-0 items-center gap-2">
+                {/* Status */}
+                <div className="flex min-w-0 shrink-0 items-center gap-2.5">
+                  <div
+                    ref={connectionPillRef}
+                    onMouseEnter={() => setStatusTooltip('connection')}
+                    onMouseLeave={() => setStatusTooltip((current) => current === 'connection' ? null : current)}
+                    className="group relative flex items-center gap-2 px-2.5 py-1.5 rounded-full bg-[color:var(--surface-1)] border border-[color:var(--border-subtle)] transition-all hover:bg-[color:var(--surface-2)] cursor-default"
                   >
-                    <span className="w-28 shrink-0 text-left text-[9px] font-bold uppercase tracking-[0.12em] text-[color:var(--text-muted)]">
-                      Instance Picker
-                    </span>
-                    <span aria-hidden="true" className="h-4 w-px shrink-0 bg-[color:var(--border-subtle)]" />
-                    <span className="block min-w-0 flex-1 truncate text-left text-xs font-semibold text-[color:var(--text-primary)]">
-                      {instancePickerLabel}
-                    </span>
-                    <ChevronDown
-                      size={13}
-                      aria-hidden="true"
-                      className={`shrink-0 text-[color:var(--text-muted)] transition-transform duration-300 ${isSessionDropdownOpen ? 'rotate-180' : ''}`}
-                    />
-                  </button>
-
-                  {isSessionDropdownOpen && sessionDropdownRect && createPortal(
+                    <div className={`h-1.5 w-1.5 rounded-full transition-all duration-500 ${streaming.connection === 'connected' ? 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.4)]' : 'bg-rose-500 shadow-[0_0_8px_rgba(244,63,94,0.4)]'}`} />
+                    <span className="text-[10px] font-bold uppercase tracking-[0.08em] text-[color:var(--text-secondary)]">{streaming.connection === 'connected' ? 'Live' : 'Offline'}</span>
+                  </div>
+                  {statusTooltip === 'connection' && connectionTooltipRect && createPortal(
                     <div
-                      ref={sessionDropdownMenuRef}
-                      role="listbox"
-                      aria-label="Switch session"
                       style={{
-                        left: sessionDropdownRect.left,
-                        top: sessionDropdownRect.top,
-                        width: Math.max(sessionDropdownRect.width, 320),
+                        position: 'fixed',
+                        top: connectionTooltipRect.top + 8,
+                        left: Math.max(8, Math.min(connectionTooltipRect.left, window.innerWidth - 220)),
+                        zIndex: 10000,
                       }}
-                      className="fixed z-[10000] max-h-80 overflow-y-auto rounded-2xl border border-[color:var(--border-strong)] bg-[color:var(--surface-0)] py-1.5 shadow-2xl backdrop-blur-xl animate-in fade-in zoom-in-95 duration-200 origin-top-left"
+                      className="px-3 py-2 rounded-xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] text-[10px] font-mono whitespace-nowrap pointer-events-none shadow-2xl animate-in fade-in slide-in-from-top-1 duration-150"
                     >
-                      {instances.length === 0 ? (
-                        <div className="px-3 py-3 text-xs text-[color:var(--text-muted)]">No instances</div>
-                      ) : (
-                        instances.map((instance) => {
-                          const title = (instance.display_name || instance.name).trim() || instance.name;
-                          const active = instance.name === activeInstanceName;
-                          return (
-                            <button
-                              key={instance.name}
-                              type="button"
-                              role="option"
-                              aria-selected={active}
-                              onClick={() => {
-                                setIsSessionDropdownOpen(false);
-                                if (!active) onInstanceClick(instance.name);
-                              }}
-                              className={`group flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors ${
-                                active
-                                  ? 'bg-[color:var(--surface-accent)] text-[color:var(--text-primary)]'
-                                  : 'text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-1)] hover:text-[color:var(--text-primary)]'
-                              }`}
-                            >
-                              <div className={`h-1.5 w-1.5 shrink-0 rounded-full ${active ? 'bg-[color:var(--accent-solid)]' : 'bg-[color:var(--text-muted)]/35 group-hover:bg-[color:var(--text-secondary)]'}`} />
-                              <span className="min-w-0 flex-1 truncate text-xs font-semibold">{title}</span>
-                              {active && <Check size={13} className="shrink-0 text-[color:var(--accent-solid)]" />}
-                            </button>
-                          );
-                        })
-                      )}
+                      <div className="font-bold uppercase tracking-wider text-[color:var(--text-muted)] mb-1">Telemetry Link</div>
+                      <div className="flex items-center gap-2">
+                        <div className={`h-1.5 w-1.5 rounded-full ${streaming.connection === 'connected' ? 'bg-emerald-500' : 'bg-rose-500'}`} />
+                        <span className={streaming.connection === 'connected' ? 'text-emerald-500 font-bold' : 'text-rose-500 font-bold'}>{streaming.connection.toUpperCase()}</span>
+                      </div>
                     </div>,
                     document.body,
                   )}
-                </div>
 
-                <button
-                  type="button"
-                  title="Instance menu"
-                  aria-label="Instance menu"
-                  onClick={() => navigate('/')}
-                  className="order-6 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] text-[color:var(--text-secondary)] shadow-sm transition-all hover:border-[color:var(--border-strong)] hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] active:scale-95"
-                >
-                  <Home size={14} />
-                </button>
-
-                <button
-                    onClick={() => setMode('solo')}
-                    className="order-1 inline-flex h-9 items-center gap-2.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm animate-[focusModePillIn_180ms_cubic-bezier(0.22,1,0.36,1)]"
-                >
-                  <Expand size={14} className="text-emerald-500/80" />
-                  Focus
-                </button>
-
-                <div className="order-2 h-4 w-px bg-[color:var(--border-subtle)] mx-1" />
-
-                <button
-                    onClick={resetSession}
-                    title="Start fresh (memories preserved)"
-                    className="order-3 inline-flex h-9 items-center gap-2.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
-                >
-                  <RefreshCw size={14} className="text-sky-500/80" />
-                  New Chat
-                </button>
-
-                <button
-                    onClick={compactContext}
-                    disabled={isCompacting}
-                    className="order-4 inline-flex h-9 items-center gap-2.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 shadow-sm"
-                >
-                  <Wand2 size={14} className={`${isCompacting ? 'animate-spin' : ''} text-amber-500/80`} />
-                  Compact
-                </button>
-              </div>
-            ) : null
-          }
-      >
-        <div className="relative flex h-full w-full overflow-hidden">
-          {mode === 'solo' ? (
-            <div className="absolute top-4 right-4 z-20">
-              <button
-                type="button"
-                onClick={() => setMode('advanced')}
-                className="inline-flex h-9 items-center gap-2 rounded-full border border-[color:var(--border-strong)] bg-[color:var(--surface-0)]/90 backdrop-blur px-4 text-[10px] font-bold uppercase tracking-widest text-[color:var(--text-primary)] hover:bg-[color:var(--surface-1)] transition-all active:scale-95 shadow-xl animate-[focusModePillIn_180ms_cubic-bezier(0.22,1,0.36,1)]"
-              >
-                <X size={14} className="text-[color:var(--text-muted)]" />
-                Exit Focus
-              </button>
-            </div>
-          ) : null}
-          {/* Chat Area */}
-          <main className="order-5 relative z-0 flex-1 flex flex-col min-w-0 bg-[color:var(--surface-0)] overflow-hidden">
-            {/* Unified Session Toolbar */}
-            {mode === 'advanced' ? (
-            <div className="flex items-center justify-between px-4 h-12 border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-0)]/80 backdrop-blur-md sticky top-0 z-30 shrink-0 select-none">
-              {/* Left: Connection & Progress */}
-              <div className="flex items-center gap-2.5">
-                <div className="group relative flex items-center gap-2 px-2.5 py-1.5 rounded-full bg-[color:var(--surface-1)] border border-[color:var(--border-subtle)] transition-all hover:bg-[color:var(--surface-2)] cursor-default">
-                  <div className={`h-1.5 w-1.5 rounded-full transition-all duration-500 ${streaming.connection === 'connected' ? 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.4)]' : 'bg-rose-500 shadow-[0_0_8px_rgba(244,63,94,0.4)]'}`} />
-                  <span className="text-[10px] font-bold uppercase tracking-[0.08em] text-[color:var(--text-secondary)]">{streaming.connection === 'connected' ? 'Live' : 'Offline'}</span>
-
-                  {/* Connection Tooltip */}
-                  <div className="absolute top-full left-0 mt-2 px-3 py-2 rounded-xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] text-[10px] font-mono whitespace-nowrap opacity-0 group-hover:opacity-100 transition-all pointer-events-none shadow-2xl z-50 translate-y-1 group-hover:translate-y-0">
-                    <div className="font-bold uppercase tracking-wider text-[color:var(--text-muted)] mb-1">Telemetry Link</div>
-                    <div className="flex items-center gap-2">
-                      <div className={`h-1.5 w-1.5 rounded-full ${streaming.connection === 'connected' ? 'bg-emerald-500' : 'bg-rose-500'}`} />
-                      <span className={streaming.connection === 'connected' ? 'text-emerald-500 font-bold' : 'text-rose-500 font-bold'}>{streaming.connection.toUpperCase()}</span>
-                    </div>
-                  </div>
-                </div>
-
-                {streaming.agentMaxIterations > 0 && (
-                  <div className="group relative flex items-center gap-3 px-3 py-1.5 rounded-full bg-[color:var(--surface-1)] border border-[color:var(--border-subtle)] transition-all hover:bg-[color:var(--surface-2)] cursor-default">
-                    <div className="w-16 h-1 rounded-full bg-[color:var(--surface-3)] overflow-hidden">
-                      <div
-                        className="h-full rounded-full bg-[color:var(--accent-solid)] transition-all duration-700 ease-out"
-                        style={{ width: `${Math.min((streaming.agentIteration / streaming.agentMaxIterations) * 100, 100)}%` }}
-                      />
-                    </div>
-                    <span className="text-[10px] font-mono font-bold text-[color:var(--text-primary)]">
-                      {streaming.agentIteration}<span className="text-[color:var(--text-muted)] mx-0.5">/</span>{streaming.agentMaxIterations}
-                    </span>
-
-                    {/* Progress Tooltip */}
-                    <div className="absolute top-full left-0 mt-2 px-3 py-2 rounded-xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] text-[10px] font-mono whitespace-nowrap opacity-0 group-hover:opacity-100 transition-all pointer-events-none shadow-2xl z-50 translate-y-1 group-hover:translate-y-0">
-                      <div className="font-bold uppercase tracking-wider text-[color:var(--text-muted)] mb-1">Execution Pipeline</div>
-                      <div><span className="font-bold text-[color:var(--accent-solid)]">{streaming.agentIteration}</span><span className="text-[color:var(--text-muted)]"> of {streaming.agentMaxIterations} steps completed</span></div>
-                      <div className="mt-1 h-1 w-full bg-[color:var(--surface-2)] rounded-full overflow-hidden">
-                        <div className="h-full bg-[color:var(--accent-solid)]" style={{ width: `${(streaming.agentIteration / streaming.agentMaxIterations) * 100}%` }} />
+                  {streaming.agentMaxIterations > 0 && (
+                    <div
+                      ref={progressPillRef}
+                      onMouseEnter={() => setStatusTooltip('progress')}
+                      onMouseLeave={() => setStatusTooltip((current) => current === 'progress' ? null : current)}
+                      className="group relative flex items-center gap-3 px-3 py-1.5 rounded-full bg-[color:var(--surface-1)] border border-[color:var(--border-subtle)] transition-all hover:bg-[color:var(--surface-2)] cursor-default"
+                    >
+                      <div className="w-16 h-1 rounded-full bg-[color:var(--surface-3)] overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-[color:var(--accent-solid)] transition-all duration-700 ease-out"
+                          style={{ width: `${Math.min((streaming.agentIteration / streaming.agentMaxIterations) * 100, 100)}%` }}
+                        />
                       </div>
+                      <span className="text-[10px] font-mono font-bold text-[color:var(--text-primary)]">
+                        {streaming.agentIteration}<span className="text-[color:var(--text-muted)] mx-0.5">/</span>{streaming.agentMaxIterations}
+                      </span>
                     </div>
-                  </div>
-                )}
-              </div>
+                  )}
+                  {statusTooltip === 'progress' && progressTooltipRect && streaming.agentMaxIterations > 0 && createPortal(
+                    <div
+                      style={{
+                        position: 'fixed',
+                        top: progressTooltipRect.top + 8,
+                        left: Math.max(8, Math.min(progressTooltipRect.left, window.innerWidth - 300)),
+                        zIndex: 10000,
+                      }}
+                      className="px-3 py-2 rounded-xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] text-[10px] font-mono whitespace-nowrap pointer-events-none shadow-2xl animate-in fade-in slide-in-from-top-1 duration-150"
+                    >
+                        <div className="font-bold uppercase tracking-wider text-[color:var(--text-muted)] mb-1">Execution Pipeline</div>
+                        <div><span className="font-bold text-[color:var(--accent-solid)]">{streaming.agentIteration}</span><span className="text-[color:var(--text-muted)]"> of {streaming.agentMaxIterations} steps completed</span></div>
+                        <div className="mt-1 h-1 w-full bg-[color:var(--surface-2)] rounded-full overflow-hidden">
+                          <div className="h-full bg-[color:var(--accent-solid)]" style={{ width: `${(streaming.agentIteration / streaming.agentMaxIterations) * 100}%` }} />
+                        </div>
+                    </div>,
+                    document.body,
+                  )}
 
-              {/* Center: Toolbar metadata removed */}
-
-              {/* Right: Controls & Context */}
-              <div className="flex items-center gap-3">
                 {/* Context Indicator */}
-                <div className="group relative flex items-center gap-2.5 px-3 py-1.5 rounded-full bg-[color:var(--surface-1)] border border-[color:var(--border-subtle)] transition-all hover:bg-[color:var(--surface-2)] cursor-default">
+                <div
+                  ref={contextPillRef}
+                  onMouseEnter={() => setStatusTooltip('context')}
+                  onMouseLeave={() => setStatusTooltip((current) => current === 'context' ? null : current)}
+                  className="group relative flex items-center gap-2.5 px-3 py-1.5 rounded-full bg-[color:var(--surface-1)] border border-[color:var(--border-subtle)] transition-all hover:bg-[color:var(--surface-2)] cursor-default"
+                >
                   {(() => {
                     const estimatedTokens = typeof contextTokenEstimate === 'number' && Number.isFinite(contextTokenEstimate) ? contextTokenEstimate : null;
                     const hasBudget = typeof contextTokenBudget === 'number' && contextTokenBudget > 0;
@@ -2700,7 +2607,16 @@ export function SessionsPage() {
                         </span>
 
                         {/* Context Tooltip */}
-                        <div className="absolute top-full right-0 mt-2 px-3 py-2.5 rounded-xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] text-[10px] font-mono whitespace-nowrap opacity-0 group-hover:opacity-100 transition-all pointer-events-none shadow-2xl z-50 translate-y-1 group-hover:translate-y-0">
+                        {statusTooltip === 'context' && contextTooltipRect && createPortal(
+                        <div
+                          style={{
+                            position: 'fixed',
+                            top: contextTooltipRect.top + 8,
+                            left: Math.max(8, Math.min(contextTooltipRect.left, window.innerWidth - 320)),
+                            zIndex: 10000,
+                          }}
+                          className="px-3 py-2.5 rounded-xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] text-[10px] font-mono whitespace-nowrap pointer-events-none shadow-2xl animate-in fade-in slide-in-from-top-1 duration-150"
+                        >
                           <div className="font-bold uppercase tracking-[0.1em] text-[color:var(--text-muted)] mb-1.5 pb-1 border-b border-[color:var(--border-subtle)]">Context Window</div>
                           <div className="flex items-center justify-between gap-8 mb-1">
                             <span className="text-[color:var(--text-secondary)]">Utilization</span>
@@ -2722,14 +2638,17 @@ export function SessionsPage() {
                             </div>
                           )}
                           {!hasEstimate && <div className="mt-1.5 text-[color:var(--text-muted)] italic">Awaiting telemetry...</div>}
-                        </div>
+                        </div>,
+                        document.body,
+                        )}
                       </>
                     );
                   })()}
                 </div>
+              </div>
 
-                <div className="w-px h-4 bg-[color:var(--border-subtle)] mx-1" />
-
+              {/* Controls */}
+              <div className="ml-auto flex shrink-0 items-center gap-3">
                 {/* Effort / Tier Selector */}
                 <div ref={effortDropdownRef} className="relative z-20">
                   {(() => {
@@ -2755,8 +2674,17 @@ export function SessionsPage() {
                       );
                     })()}
 
-                  {isEffortDropdownOpen && (
-                      <div className="absolute top-full right-0 mt-2 w-72 rounded-2xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] shadow-2xl z-50 overflow-hidden py-1.5 animate-in fade-in zoom-in-95 duration-200 origin-top-right backdrop-blur-xl">
+                  {isEffortDropdownOpen && effortDropdownRect && createPortal(
+                      <div
+                        ref={effortDropdownMenuRef}
+                        style={{
+                          position: 'fixed',
+                          top: effortDropdownRect.top + 8,
+                          left: Math.max(8, Math.min(effortDropdownRect.left + effortDropdownRect.triggerWidth - 288, window.innerWidth - 296)),
+                          zIndex: 10000,
+                        }}
+                        className="w-72 rounded-2xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] shadow-2xl overflow-hidden py-1.5 animate-in fade-in zoom-in-95 duration-200 origin-top-right backdrop-blur-xl"
+                      >
                         {models.map(m => {
                           const active = selectedTier === m.tier;
                           const tier = m.tier ?? 'normal';
@@ -2812,7 +2740,8 @@ export function SessionsPage() {
                             </button>
                           );
                         })}
-                      </div>
+                      </div>,
+                      document.body,
                   )}
                 </div>
 
@@ -2840,8 +2769,17 @@ export function SessionsPage() {
                     );
                   })()}
 
-                  {isAgentModeDropdownOpen && agentModes.length > 0 && (
-                    <div className="absolute top-full right-0 mt-2 w-72 rounded-2xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] shadow-2xl z-50 overflow-hidden py-1.5 animate-in fade-in zoom-in-95 duration-200 origin-top-right backdrop-blur-xl">
+                  {isAgentModeDropdownOpen && agentModes.length > 0 && agentModeDropdownRect && createPortal(
+                    <div
+                      ref={agentModeDropdownMenuRef}
+                      style={{
+                        position: 'fixed',
+                        top: agentModeDropdownRect.top + 8,
+                        left: Math.max(8, Math.min(agentModeDropdownRect.left + agentModeDropdownRect.triggerWidth - 288, window.innerWidth - 296)),
+                        zIndex: 10000,
+                      }}
+                      className="w-72 rounded-2xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] shadow-2xl overflow-hidden py-1.5 animate-in fade-in zoom-in-95 duration-200 origin-top-right backdrop-blur-xl"
+                    >
                       {agentModes.map((modeOption) => {
                         const active = selectedAgentMode === modeOption.id;
                         return (
@@ -2874,7 +2812,8 @@ export function SessionsPage() {
                           </button>
                         );
                       })}
-                    </div>
+                    </div>,
+                    document.body,
                   )}
                 </div>
 
@@ -2892,9 +2831,45 @@ export function SessionsPage() {
                   </select>
                 </div>
 
+                <button
+                    onClick={resetSession}
+                    title="Start fresh (memories preserved)"
+                    className="inline-flex h-9 items-center gap-2.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
+                >
+                  <RefreshCw size={14} className="text-sky-500/80" />
+                  New Chat
+                </button>
+
+                <button
+                    onClick={compactContext}
+                    disabled={isCompacting}
+                    className="inline-flex h-9 items-center gap-2.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 shadow-sm"
+                >
+                  <Wand2 size={14} className={`${isCompacting ? 'animate-spin' : ''} text-amber-500/80`} />
+                  Compact
+                </button>
+
               </div>
+              </div>
+            ) : null
+          }
+      >
+        <div className="relative flex h-full w-full overflow-hidden">
+          {mode === 'solo' ? (
+            <div className="absolute top-4 right-4 z-20">
+              <button
+                type="button"
+                onClick={() => setMode('advanced')}
+                className="inline-flex h-9 items-center gap-2 rounded-full border border-[color:var(--border-strong)] bg-[color:var(--surface-0)]/90 backdrop-blur px-4 text-[10px] font-bold uppercase tracking-widest text-[color:var(--text-primary)] hover:bg-[color:var(--surface-1)] transition-all active:scale-95 shadow-xl animate-[focusModePillIn_180ms_cubic-bezier(0.22,1,0.36,1)]"
+              >
+                <X size={14} className="text-[color:var(--text-muted)]" />
+                Exit Focus
+              </button>
             </div>
-            ) : null}
+          ) : null}
+          {/* Chat Area */}
+          <main className="order-5 relative z-0 flex-1 flex flex-col min-w-0 bg-[color:var(--surface-0)] overflow-hidden">
+            {/* Session toolbar items moved into the pane-header actions */}
 
             {/* Messages */}
             <div

--- a/apps/frontend/sentinel/src/pages/SessionsPage.tsx
+++ b/apps/frontend/sentinel/src/pages/SessionsPage.tsx
@@ -15,6 +15,7 @@ import {
   ExternalLink,
   Zap,
   Activity,
+  Gauge,
   Brain,
   Sparkles,
   Paperclip,
@@ -587,6 +588,7 @@ export function SessionsPage() {
     () => parseTier(localStorage.getItem('sentinel-selected-tier')) ?? 'normal',
   );
   const [isAgentModeDropdownOpen, setIsAgentModeDropdownOpen] = useState(false);
+  const [isMaxDropdownOpen, setIsMaxDropdownOpen] = useState(false);
   const [isEffortDropdownOpen, setIsEffortDropdownOpen] = useState(false);
   const [maxIterations, setMaxIterations] = useState(50);
 
@@ -729,7 +731,7 @@ export function SessionsPage() {
   }, [selectedAgentMode]);
 
   useEffect(() => {
-    if (!isSessionDropdownOpen && !isEffortDropdownOpen && !isAgentModeDropdownOpen) return;
+    if (!isSessionDropdownOpen && !isEffortDropdownOpen && !isAgentModeDropdownOpen && !isMaxDropdownOpen) return;
     const handlePointerDown = (event: MouseEvent) => {
       const target = event.target as Node | null;
       if (!target) return;
@@ -739,6 +741,8 @@ export function SessionsPage() {
       if (effortDropdownMenuRef.current?.contains(target)) return;
       if (agentModeDropdownRef.current?.contains(target)) return;
       if (agentModeDropdownMenuRef.current?.contains(target)) return;
+      if (maxDropdownRef.current?.contains(target)) return;
+      if (maxDropdownMenuRef.current?.contains(target)) return;
       setIsSessionDropdownOpen(false);
       setIsEffortDropdownOpen(false);
       setIsAgentModeDropdownOpen(false);
@@ -747,7 +751,7 @@ export function SessionsPage() {
     return () => {
       document.removeEventListener('mousedown', handlePointerDown);
     };
-  }, [isSessionDropdownOpen, isEffortDropdownOpen, isAgentModeDropdownOpen]);
+  }, [isSessionDropdownOpen, isEffortDropdownOpen, isAgentModeDropdownOpen, isMaxDropdownOpen]);
 
   const updateSessionDropdownRect = useCallback(() => {
     const button = sessionDropdownButtonRef.current;
@@ -798,6 +802,8 @@ export function SessionsPage() {
   const effortDropdownMenuRef = useRef<HTMLDivElement | null>(null);
   const agentModeDropdownRef = useRef<HTMLDivElement | null>(null);
   const agentModeDropdownMenuRef = useRef<HTMLDivElement | null>(null);
+  const maxDropdownRef = useRef<HTMLDivElement | null>(null);
+  const maxDropdownMenuRef = useRef<HTMLDivElement | null>(null);
   const connectionPillRef = useRef<HTMLDivElement | null>(null);
   const progressPillRef = useRef<HTMLDivElement | null>(null);
   const contextPillRef = useRef<HTMLDivElement | null>(null);
@@ -806,6 +812,7 @@ export function SessionsPage() {
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
   const effortDropdownRect = useAnchorRect(effortDropdownRef, isEffortDropdownOpen);
   const agentModeDropdownRect = useAnchorRect(agentModeDropdownRef, isAgentModeDropdownOpen);
+  const maxDropdownRect = useAnchorRect(maxDropdownRef, isMaxDropdownOpen);
   const connectionTooltipRect = useAnchorRect(connectionPillRef, statusTooltip === 'connection');
   const progressTooltipRect = useAnchorRect(progressPillRef, statusTooltip === 'progress');
   const contextTooltipRect = useAnchorRect(contextPillRef, statusTooltip === 'context');
@@ -2665,7 +2672,7 @@ export function SessionsPage() {
                             setIsAgentModeDropdownOpen(false);
                             setIsEffortDropdownOpen(!isEffortDropdownOpen);
                           }}
-                          className="flex items-center gap-2.5 px-3 h-8 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] hover:bg-[color:var(--surface-1)] hover:border-[color:var(--border-strong)] transition-all shadow-sm"
+                          className="flex items-center gap-2 px-3 h-7 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] hover:bg-[color:var(--surface-2)] hover:border-[color:var(--border-strong)] transition-all shadow-sm"
                         >
                           <span className="text-[color:var(--text-secondary)]">{icons[tier] || <Activity size={11} />}</span>
                           <span className="text-[10px] font-bold uppercase tracking-widest text-[color:var(--text-primary)]">{active?.label || 'Mode'}</span>
@@ -2746,7 +2753,7 @@ export function SessionsPage() {
                 </div>
 
                 {/* Agent Mode Selector */}
-                <div ref={agentModeDropdownRef} className="relative z-20 pl-2 border-l border-[color:var(--border-subtle)]">
+                <div ref={agentModeDropdownRef} className="relative z-20">
                   {(() => {
                     const active = agentModes.find((item) => item.id === selectedAgentMode) ?? agentModes[0];
                     return (
@@ -2757,7 +2764,7 @@ export function SessionsPage() {
                           setIsAgentModeDropdownOpen((prev) => !prev);
                         }}
                         disabled={agentModes.length === 0}
-                        className="flex items-center gap-2.5 px-3 h-8 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] hover:bg-[color:var(--surface-1)] hover:border-[color:var(--border-strong)] transition-all shadow-sm disabled:opacity-40 disabled:cursor-not-allowed"
+                        className="flex items-center gap-2 px-3 h-7 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] hover:bg-[color:var(--surface-2)] hover:border-[color:var(--border-strong)] transition-all shadow-sm disabled:opacity-40 disabled:cursor-not-allowed"
                         title={active?.description ?? 'Agent mode'}
                       >
                         <span className="text-[color:var(--text-secondary)]"><Bot size={11} /></span>
@@ -2817,24 +2824,69 @@ export function SessionsPage() {
                   )}
                 </div>
 
-                {/* Steps Selector */}
-                <div className="flex items-center gap-2 pl-2 border-l border-[color:var(--border-subtle)]">
-                  <span className="text-[9px] font-bold uppercase tracking-widest text-[color:var(--text-muted)]">Max</span>
-                  <select
-                      value={maxIterations}
-                      onChange={(e) => setMaxIterations(Number(e.target.value))}
-                      className="bg-transparent text-[11px] font-bold outline-none cursor-pointer hover:text-[color:var(--accent-solid)] transition-colors pr-1"
+                {/* Max Steps Selector */}
+                <div ref={maxDropdownRef} className="relative z-20">
+                  <button
+                    onClick={() => {
+                      setIsEffortDropdownOpen(false);
+                      setIsAgentModeDropdownOpen(false);
+                      setIsMaxDropdownOpen((prev) => !prev);
+                    }}
+                    title="Maximum agent steps per run"
+                    className="flex items-center gap-2 px-3 h-7 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] hover:bg-[color:var(--surface-2)] hover:border-[color:var(--border-strong)] transition-all shadow-sm"
                   >
-                    {[5, 10, 20, 30, 50, 100].map(n => (
-                      <option key={n} value={n} className="bg-[color:var(--surface-0)]">{n}</option>
-                    ))}
-                  </select>
+                    <span className="text-[color:var(--text-secondary)]"><Gauge size={11} /></span>
+                    <span className="text-[9px] font-bold uppercase tracking-widest text-[color:var(--text-muted)]">Max Steps</span>
+                    <span className="text-[10px] font-bold tabular-nums tracking-widest text-[color:var(--text-primary)]">{maxIterations}</span>
+                    <ChevronDown size={11} className={`transition-transform duration-300 opacity-40 ${isMaxDropdownOpen ? 'rotate-180' : ''}`} />
+                  </button>
+
+                  {isMaxDropdownOpen && maxDropdownRect && createPortal(
+                    <div
+                      ref={maxDropdownMenuRef}
+                      style={{
+                        position: 'fixed',
+                        top: maxDropdownRect.top + 8,
+                        left: Math.max(8, Math.min(maxDropdownRect.left + maxDropdownRect.triggerWidth - 224, window.innerWidth - 232)),
+                        zIndex: 10000,
+                      }}
+                      className="w-56 rounded-2xl bg-[color:var(--surface-0)] border border-[color:var(--border-strong)] shadow-2xl overflow-hidden py-1.5 animate-in fade-in zoom-in-95 duration-200 origin-top-right backdrop-blur-xl"
+                    >
+                      <div className="px-4 py-2 text-[9px] font-bold uppercase tracking-widest text-[color:var(--text-muted)] border-b border-[color:var(--border-subtle)]">
+                        Max steps per run
+                      </div>
+                      {[5, 10, 20, 30, 50, 100].map((n) => {
+                        const active = maxIterations === n;
+                        return (
+                          <button
+                            key={n}
+                            onClick={() => {
+                              setMaxIterations(n);
+                              setIsMaxDropdownOpen(false);
+                            }}
+                            className={`w-full flex items-center gap-2.5 px-4 py-2.5 transition-all text-left ${
+                              active
+                                ? 'bg-[color:var(--accent-solid)] text-[color:var(--app-bg)]'
+                                : 'hover:bg-[color:var(--surface-1)]'
+                            }`}
+                          >
+                            <span className={`text-[11px] font-bold tabular-nums ${active ? 'text-[color:var(--app-bg)]' : 'text-[color:var(--text-primary)]'}`}>{n}</span>
+                            <span className={`text-[9px] font-medium ${active ? 'text-[color:var(--app-bg)] opacity-70' : 'text-[color:var(--text-muted)]'}`}>steps</span>
+                            {active && (
+                              <div className="ml-auto w-1 h-5 rounded-full bg-[color:var(--app-bg)]/20 shadow-sm" />
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>,
+                    document.body,
+                  )}
                 </div>
 
                 <button
                     onClick={resetSession}
                     title="Start fresh (memories preserved)"
-                    className="inline-flex h-9 items-center gap-2.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
+                    className="inline-flex h-7 items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-3 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
                 >
                   <RefreshCw size={14} className="text-sky-500/80" />
                   New Chat
@@ -2843,7 +2895,7 @@ export function SessionsPage() {
                 <button
                     onClick={compactContext}
                     disabled={isCompacting}
-                    className="inline-flex h-9 items-center gap-2.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 shadow-sm"
+                    className="inline-flex h-7 items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-3 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 shadow-sm"
                 >
                   <Wand2 size={14} className={`${isCompacting ? 'animate-spin' : ''} text-amber-500/80`} />
                   Compact

--- a/apps/frontend/sentinel/src/pages/SessionsPage.tsx
+++ b/apps/frontend/sentinel/src/pages/SessionsPage.tsx
@@ -7,18 +7,13 @@ import {
   Loader2,
   Plus,
   RefreshCw,
-  RotateCcw,
   Send,
-  Settings2,
   Users,
   Square,
   Wand2,
   Wrench,
   X,
-  Trash2,
   Terminal,
-  Folder,
-  Globe,
   ExternalLink,
   Zap,
   Activity,
@@ -30,9 +25,6 @@ import {
   GitBranch,
   CheckCircle2,
   AlertCircle,
-  XCircle,
-  Copy,
-  HelpCircle,
 } from 'lucide-react';
 import { ChangeEvent, ClipboardEvent, FormEvent, useEffect, useMemo, useRef, useState, memo, useCallback, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
@@ -42,19 +34,15 @@ import { toast } from 'sonner';
 import { AppShell } from '../components/AppShell';
 import { SessionMessageCard, buildToolArgumentsByCallId, ToolPayloadView, ToolPayloadCompactSummary } from '../components/session/SessionMessageCard';
 import { SessionHistorySidebar } from '../components/session/SessionHistorySidebar';
-import { DesktopPreview } from '../components/session/DesktopPreview';
-import { TerminalPreview } from '../components/session/TerminalPreview';
 import { useSessionDeleteConfirmation } from '../components/session/SessionDeleteConfirmDialog';
 import { getTerminalLabel, summarizeCommand } from '../lib/terminalIdentity';
 import { SubAgentTaskModal } from '../components/SubAgentTaskModal';
 import { SpawnSubAgentModal } from '../components/SpawnSubAgentModal';
 import { Markdown } from '../components/ui/Markdown';
-import { WorkbenchExplorerPane } from '../components/workbench/WorkbenchExplorerPane';
-import { Workbench, type WorkbenchTab } from '../components/workbench/Workbench';
+import { Workbench } from '../components/workbench/Workbench';
 import { StatusChip } from '../components/ui/StatusChip';
-import { SESSION_DEBUG_PANEL_ENABLED, wsSessionsBaseUrl } from '../lib/env';
+import { SESSION_DEBUG_PANEL_ENABLED } from '../lib/env';
 import { toPrettyJson, truncate } from '../lib/format';
-import { buildRuntimeGitChangedTree } from '../lib/runtimeGitTree';
 import {
   approvalKey,
   approvalRefFromMetadata,
@@ -65,6 +53,9 @@ import { api } from '../lib/api';
 import { useInstanceName, useWorkspaceMode } from '../lib/workspace-context';
 import { instanceRouteFromPath } from '../lib/routes';
 import { getSessionDeleteWorkspaceSummary } from '../lib/sessionDeletion';
+import { useSetActiveSession } from '../store/active-session-store';
+import { useSessionRuntimeStream } from '../hooks/useSessionRuntimeStream';
+import { useSessionWorkbench } from '../hooks/useSessionWorkbench';
 import {
   applyToolcallEnd,
   applyToolResult,
@@ -83,38 +74,15 @@ import type {
   MessageListResponse,
   ModelOption,
   ModelsResponse,
-  RuntimeActionResponse,
-  RuntimeLiveView,
-  RuntimeStatusResponse,
   Session,
   SessionContextUsage,
-  SessionRuntimeFileEntry,
-  SessionRuntimeFilePreviewResponse,
-  SessionRuntimeFilesResponse,
-  SessionRuntimeGitChangedFilesResponse,
-  SessionRuntimeGitDiffResponse,
-  SessionRuntimeGitRoot,
-  SessionRuntimeGitRootsResponse,
   SessionListResponse,
   SubAgentTask,
   SubAgentTaskListResponse,
-  WsConnectionState,
   WsEvent,
 } from '../types/api';
 
 // --- Utility Functions ---
-
-const DESKTOP_RESOLUTION_PRESETS = [
-  { value: '1280x800', label: '1280 x 800' },
-  { value: '1440x900', label: '1440 x 900' },
-  { value: '1680x1050', label: '1680 x 1050' },
-  { value: '1920x1200', label: '1920 x 1200' },
-  { value: '2560x1600', label: '2560 x 1600' },
-  { value: '2880x1800', label: '2880 x 1800' },
-  { value: '3840x2400', label: '3840 x 2400' },
-];
-
-const DEFAULT_DESKTOP_RESOLUTION = '1920x1200';
 
 function taskStatusTone(status: string): 'default' | 'good' | 'warn' | 'danger' | 'info' {
   switch (status) {
@@ -193,46 +161,14 @@ interface SentinelInstance {
   runtime_id: string | null;
 }
 
-// Top-level right-rail tabs. `runtime` is a composite tab that contains
-// three sub-views (Desktop / Terminals / Files) selected via an inner
-// segmented control — see `RuntimeView` below. The previous flat enum
-// (desktop / terminals / runtime / …) collapsed those three siblings into
-// one parent so the rail stays under three primary tabs.
-type RightRailTab = 'runtime' | 'sub_agents' | 'sessions' | 'debug';
-type RuntimeView = 'desktop' | 'terminals' | 'files';
+// Top-level right-rail tabs. The Desktop / Terminals / Files runtime surfaces
+// moved out of SessionsPage into standalone workspace tabs (DesktopTab /
+// TerminalTab / FilesTab), so the rail keeps only the chat-adjacent panels:
+// sub-agent tasks, session history, and the debug panel.
+type RightRailTab = 'sub_agents' | 'sessions' | 'debug';
 
-interface ActiveTerminal {
-  id: string;
-  /** Backend-supplied label, used only as a fallback for auto-allocated terminals. */
-  label: string | null;
-  createdBy: 'agent' | 'user';
-  createdAt: number;
-  auto: boolean;
-  busy: boolean;
-  /** Most recent command run in this terminal (for tooltip + rail header). */
-  lastCommand: string | null;
-}
-
-function buildRuntimeDiffBaseRefOptions(
-  roots: SessionRuntimeGitRoot[],
-  currentRef: string | null | undefined,
-): string[] {
-  const options = new Set<string>();
-  options.add('HEAD');
-  for (const root of roots) {
-    if (!root.detached_head && root.branch) {
-      options.add(root.branch);
-      options.add(`origin/${root.branch}`);
-    }
-  }
-  options.add('origin/main');
-  options.add('origin/master');
-  const normalizedCurrent = (currentRef ?? '').trim();
-  if (normalizedCurrent) {
-    options.add(normalizedCurrent);
-  }
-  return Array.from(options);
-}
+// ActiveTerminal lives in useSessionRuntimeStream; the diff base-ref option
+// builder lives in useSessionWorkbench.
 
 function humanizeAgentError(raw: string): string {
   const lower = raw.toLowerCase();
@@ -673,92 +609,85 @@ export function SessionsPage() {
 
   const [tasks, setTasks] = useState<SubAgentTask[]>([]);
   const [tasksLoading, setTasksLoading] = useState(false);
-  const [rightRailTab, setRightRailTab] = useState<RightRailTab>('runtime');
-  // Selected sub-view inside the Runtime tab. Defaults to Desktop (the most
-  // recognizable "what is the agent doing" surface). Auto-promoted to
-  // `terminals` the first time a terminal opens — see the terminal_opened
-  // WS handler below for the rule.
-  const [runtimeView, setRuntimeView] = useState<RuntimeView>('desktop');
-  // Tracks the moment the user last manually picked a runtimeView. Used to
-  // suppress auto-focus when the user has just expressed an intent — we
-  // don't want the agent's activity stealing focus a half-second later.
-  const lastRuntimeViewIntentRef = useRef<number>(0);
-  // Refs to the three runtime sub-tab buttons + the strip container, so the
-  // sliding indicator can size to the *actual* active button instead of a
-  // calc'd third. When the rail is narrow and a button's content (icon +
-  // label + badge) overflows its grid cell, the cell-based indicator falls
-  // out of alignment — measuring offsetLeft/offsetWidth dodges that whole
-  // class of bug.
-  const runtimeTabRefs = useRef<Record<RuntimeView, HTMLButtonElement | null>>({
-    desktop: null,
-    terminals: null,
-    files: null,
-  });
-  const runtimeStripRef = useRef<HTMLDivElement | null>(null);
-  const [runtimeIndicator, setRuntimeIndicator] = useState<{ left: number; width: number } | null>(null);
-  // Centralised predicates so every conditional in the file reads the same
-  // way and a future rename only touches one line. The Runtime tab is a
-  // composite, so individual sub-views are gated on both rightRailTab AND
-  // runtimeView.
-  const isRuntimeTab = rightRailTab === 'runtime';
-  const showDesktopView = isRuntimeTab && runtimeView === 'desktop';
-  const showTerminalsView = isRuntimeTab && runtimeView === 'terminals';
-  const showFilesView = isRuntimeTab && runtimeView === 'files';
+  const [rightRailTab, setRightRailTab] = useState<RightRailTab>('sessions');
   // Pills above the chat composer surface every tmux-backed terminal the
   // agent (or the user) has opened in the current chat session. State is
   // driven by `terminal_opened/closed/busy` WS events plus the initial
   // `connected` payload that lists already-live terminals on page load.
-  const [activeTerminals, setActiveTerminals] = useState<ActiveTerminal[]>([]);
-  const [focusedTerminalId, setFocusedTerminalId] = useState<string | null>(null);
+  //
+  // The terminal list, the noVNC live-view payload, runtime status, and the
+  // desktop-resolution actions all live in `useSessionRuntimeStream`, which
+  // owns the SHARED, ref-counted session WS stream. The Desktop / Terminals /
+  // Files surfaces themselves now live in standalone workspace tabs that
+  // consume the same shared hooks; SessionsPage only keeps the chat-adjacent
+  // pieces (terminal pills + the chat stream tap). The chat stream consumes the
+  // socket through this hook's `onEvent` tap — one socket per session.
+  const setActiveSession = useSetActiveSession();
 
-  // Position the runtime-tabs sliding indicator under the active button.
-  // useLayoutEffect runs before paint, so the indicator never flashes at the
-  // wrong width. We re-measure on view change, on badge changes (since they
-  // mutate button widths), and on rail resize via ResizeObserver below.
-  useLayoutEffect(() => {
-    if (!isRuntimeTab) return;
-    const active = runtimeTabRefs.current[runtimeView];
-    if (!active) return;
-    setRuntimeIndicator({ left: active.offsetLeft, width: active.offsetWidth });
-  }, [isRuntimeTab, runtimeView, activeTerminals.length]);
+  // Per-session runtime stream. Owns the shared, ref-counted WS connection; the
+  // chat stream taps the same socket via `onEvent`. The standalone runtime tabs
+  // subscribe to the same (instance, session) pair, so opening them reuses this
+  // socket. `desktopViewActive` is false here — SessionsPage no longer hosts the
+  // desktop surface, so it must not drive the live-view poll.
+  const runtime = useSessionRuntimeStream(activeInstanceName, activeSessionId, {
+    desktopViewActive: false,
+    onReconnectFailed: () => {
+      toast.error('Realtime stream disconnected');
+    },
+    onEvent: (event) => {
+      onStreamEvent(activeSessionIdRef.current ?? '', event);
+    },
+  });
+  const {
+    connection: runtimeConnection,
+    isStreamOpen,
+    sendMessage: sendStreamMessage,
+    activeTerminals,
+    focusedTerminalId,
+    setFocusedTerminalId,
+    dropTerminal,
+    setLiveView,
+    runtimeBooting,
+    setRuntimeBooting,
+  } = runtime;
 
-  useEffect(() => {
-    const strip = runtimeStripRef.current;
-    if (!strip || !isRuntimeTab) return;
-    // Strip width changes when the user resizes the right rail. Reread the
-    // active button's box and reapply. ResizeObserver fires once on attach
-    // too, so this also handles the initial mount cleanly.
-    const observer = new ResizeObserver(() => {
-      const active = runtimeTabRefs.current[runtimeView];
-      if (!active) return;
-      setRuntimeIndicator({ left: active.offsetLeft, width: active.offsetWidth });
-    });
-    observer.observe(strip);
-    return () => observer.disconnect();
-  }, [isRuntimeTab, runtimeView]);
-  const [runtimeFiles, setRuntimeFiles] = useState<SessionRuntimeFilesResponse | null>(null);
-  const [runtimeFilesLoading, setRuntimeFilesLoading] = useState(false);
-  const [runtimeFilesRefreshKey, setRuntimeFilesRefreshKey] = useState(0);
-  const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatusResponse | null>(null);
-  const [runtimeStatusLoading, setRuntimeStatusLoading] = useState(false);
-  const [showPassingRuntimeChecks, setShowPassingRuntimeChecks] = useState(false);
-  const [showOptionalRuntimeWarnings, setShowOptionalRuntimeWarnings] = useState(false);
-
-  const [runtimePath, setRuntimePath] = useState('');
-  const [runtimeRepoChangesByRoot, setRuntimeRepoChangesByRoot] = useState<Record<string, SessionRuntimeGitChangedFilesResponse | null>>({});
-  const [runtimeRepoChangesLoadingByRoot, setRuntimeRepoChangesLoadingByRoot] = useState<Record<string, boolean>>({});
-  const [runtimeExpandedGitDirs, setRuntimeExpandedGitDirs] = useState<Record<string, boolean>>({});
-  const [workbenchTabs, setWorkbenchTabs] = useState<WorkbenchTab[]>([]);
-  const [activeWorkbenchPath, setActiveWorkbenchPath] = useState<string | null>(null);
-  const [workbenchLoadingPath, setWorkbenchLoadingPath] = useState<string | null>(null);
+  // Files / workbench surface (directory browse, open-file view, diff, repo
+  // changes, download). Owned by the shared workbench hook; SessionsPage just
+  // wires its props. Stale-session guarding lives inside the hook.
+  const workbench = useSessionWorkbench(activeSessionId);
+  const {
+    runtimeFiles,
+    runtimePath,
+    runtimeFilesLoading,
+    runtimeFilesRefreshKey,
+    fetchRuntimeFiles,
+    bumpRuntimeFilesRefreshKey,
+    loadRuntimeDirectoryEntries,
+    downloadRuntimeEntry,
+    repoChangeSections: runtimeRepoChangeSections,
+    expandedGitDirs: runtimeExpandedGitDirs,
+    toggleGitDir,
+    fetchChangedFilesForRepo,
+    forgetRepoRoot,
+    workbenchTabs,
+    activeWorkbenchPath,
+    setActiveWorkbenchPath,
+    activeWorkbenchTab,
+    openRuntimeFile,
+    openRuntimeFileDiff,
+    closeWorkbenchTab,
+    closeAllWorkbenchTabs,
+    workbenchShowDiffByPath,
+    setShowDiffForPath,
+    activeWorkbenchDiff,
+    activeWorkbenchDiffError,
+    activeWorkbenchDiffLoading,
+    activeWorkbenchBaseRef,
+    setDiffBaseRefForPath,
+    activeWorkbenchBaseRefOptions,
+  } = workbench;
   const [workbenchWidth, setWorkbenchWidth] = useState(442);
   const [isWorkbenchResizing, setIsWorkbenchResizing] = useState(false);
-  const [workbenchShowDiffByPath, setWorkbenchShowDiffByPath] = useState<Record<string, boolean>>({});
-  const [workbenchDiffBaseRefByPath, setWorkbenchDiffBaseRefByPath] = useState<Record<string, string>>({});
-  const [workbenchDiffByPath, setWorkbenchDiffByPath] = useState<Record<string, SessionRuntimeGitDiffResponse | null>>({});
-  const [workbenchDiffErrorByPath, setWorkbenchDiffErrorByPath] = useState<Record<string, string | null>>({});
-  const [workbenchDiffLoadingPath, setWorkbenchDiffLoadingPath] = useState<string | null>(null);
-  const [workbenchGitRootsByPath, setWorkbenchGitRootsByPath] = useState<Record<string, SessionRuntimeGitRoot[]>>({});
   const [spawnObjective, setSpawnObjective] = useState('');
   const [spawnScope, setSpawnScope] = useState('');
   const [spawnMaxSteps, setSpawnMaxSteps] = useState(5);
@@ -770,9 +699,6 @@ export function SessionsPage() {
   const [isTerminatingTask, setIsTerminatingTask] = useState(false);
   const [confirmTerminateTaskId, setConfirmTerminateTaskId] = useState<string | null>(null);
 
-  const [liveView, setLiveView] = useState<RuntimeLiveView | null>(null);
-  const [runtimeBooting, setRuntimeBooting] = useState(false);
-  const isDesktopRuntimeStarting = Boolean(liveView?.enabled && !liveView.available) || runtimeBooting;
   const [debugMenuOpen, setDebugMenuOpen] = useState(false);
   const [debugEvents, setDebugEvents] = useState<SessionDebugEvent[]>([]);
   const [mode, setMode] = useState<'solo' | 'advanced'>(
@@ -780,20 +706,15 @@ export function SessionsPage() {
   );
 
   const hasActiveSubAgentTasks = tasks.some((task) => task.status === 'running' || task.status === 'pending');
-  const runtimeRepoChangeSections = useMemo(
-    () =>
-      Object.entries(runtimeRepoChangesByRoot).map(([rootPath, payload]) => ({
-        id: rootPath,
-        title:
-          (payload?.git_root || rootPath)
-            .split('/')
-            .filter(Boolean)
-            .pop() || rootPath || 'repo',
-        tree: buildRuntimeGitChangedTree(payload),
-        loading: Boolean(runtimeRepoChangesLoadingByRoot[rootPath]),
-      })),
-    [runtimeRepoChangesByRoot, runtimeRepoChangesLoadingByRoot],
-  );
+
+  // Mirror the shared stream's connection state into the chat `streaming`
+  // state so existing UI that reads `streaming.connection` stays accurate now
+  // that the WebSocket lives in the runtime hook rather than inline here.
+  useEffect(() => {
+    setStreaming((current) =>
+      current.connection === runtimeConnection ? current : { ...current, connection: runtimeConnection },
+    );
+  }, [runtimeConnection]);
 
   useEffect(() => {
     localStorage.setItem('sentinel-mode', mode);
@@ -851,33 +772,8 @@ export function SessionsPage() {
 
   const [isCompacting, setIsCompacting] = useState(false);
   const [isStopping, setIsStopping] = useState(false);
-  const [runtimeActionBusy, setRuntimeActionBusy] = useState(false);
-  const [isDesktopResolutionChanging, setIsDesktopResolutionChanging] = useState(false);
-  const [desktopResolution, setDesktopResolutionState] = useState(() => (
-    localStorage.getItem('sentinel-desktop-resolution') || DEFAULT_DESKTOP_RESOLUTION
-  ));
-  const [desktopLayoutNonce, setDesktopLayoutNonce] = useState(0);
-  const [resetMenuOpen, setResetMenuOpen] = useState(false);
-  const resetMenuRef = useRef<HTMLDivElement>(null);
-  const [isDesktopFullscreen, setIsDesktopFullscreen] = useState(false);
   const [rightPanelWidth, setRightPanelWidth] = useState(400);
   const [isResizing, setIsResizing] = useState(false);
-
-  useEffect(() => {
-    if (isDesktopFullscreen) {
-      setResetMenuOpen(false);
-      setIsSessionDropdownOpen(false);
-      setIsEffortDropdownOpen(false);
-      setIsAgentModeDropdownOpen(false);
-    }
-  }, [isDesktopFullscreen]);
-
-  useEffect(() => {
-    if (!DESKTOP_RESOLUTION_PRESETS.some((preset) => preset.value === desktopResolution)) {
-      setDesktopResolutionState(DEFAULT_DESKTOP_RESOLUTION);
-      localStorage.setItem('sentinel-desktop-resolution', DEFAULT_DESKTOP_RESOLUTION);
-    }
-  }, [desktopResolution]);
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const messagesRef = useRef<Message[]>([]);
@@ -889,74 +785,26 @@ export function SessionsPage() {
   const prependScrollAnchorRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null);
   const oldestServerMessageIdRef = useRef<string | null>(null);
   const loadingOlderRef = useRef(false);
-  const wsRef = useRef<WebSocket | null>(null);
+  // The session WebSocket + reconnect now live in the shared stream manager
+  // (see `useSessionRuntimeStream` / `session-stream.ts`); no inline ws/reconnect
+  // refs remain here.
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const sessionDropdownRef = useRef<HTMLDivElement | null>(null);
   const sessionDropdownButtonRef = useRef<HTMLButtonElement | null>(null);
   const sessionDropdownMenuRef = useRef<HTMLDivElement | null>(null);
   const effortDropdownRef = useRef<HTMLDivElement | null>(null);
   const agentModeDropdownRef = useRef<HTMLDivElement | null>(null);
-  const fullscreenFrameRef = useRef<HTMLIFrameElement | null>(null);
-  const intentionalCloseRef = useRef(false);
-  const reconnectTimerRef = useRef<number | null>(null);
-  const reconnectAttemptsRef = useRef(0);
   const activeSessionIdRef = useRef<string | null>(routeSessionId ?? null);
   const contextUsageRequestRef = useRef(0);
-  const wsInstanceRef = useRef(0);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
-  const shouldRestoreComposerFocusRef = useRef(true);
-  const composerFocusTimerRefs = useRef<number[]>([]);
 
   // Keep refs in sync so WS callbacks can read current values
   useEffect(() => { activeSessionIdRef.current = activeSessionId; }, [activeSessionId]);
   useEffect(() => { messagesRef.current = messages; }, [messages]);
   useEffect(() => {
-    return () => {
-      composerFocusTimerRefs.current.forEach((timer) => window.clearTimeout(timer));
-      composerFocusTimerRefs.current = [];
-    };
-  }, []);
-  useEffect(() => {
     setRetryCandidate(null);
     setRetryingMessageId(null);
-    composerFocusTimerRefs.current.forEach((timer) => window.clearTimeout(timer));
-    composerFocusTimerRefs.current = [];
-    shouldRestoreComposerFocusRef.current = true;
   }, [activeSessionId]);
-
-  const handleDesktopInteract = useCallback(() => {
-    shouldRestoreComposerFocusRef.current = false;
-    composerFocusTimerRefs.current.forEach((timer) => window.clearTimeout(timer));
-    composerFocusTimerRefs.current = [];
-  }, []);
-
-  const handleDesktopFrameLoad = useCallback(() => {
-    if (!shouldRestoreComposerFocusRef.current) return;
-    if (!showDesktopView || isDesktopFullscreen) return;
-
-    composerFocusTimerRefs.current.forEach((timer) => window.clearTimeout(timer));
-    composerFocusTimerRefs.current = [];
-
-    const restoreFocus = () => {
-      if (!shouldRestoreComposerFocusRef.current) return;
-      const activeElement = document.activeElement as HTMLElement | null;
-      const activeTag = activeElement?.tagName;
-      const canRestoreFocus =
-        !activeElement ||
-        activeElement === document.body ||
-        activeElement === document.documentElement ||
-        activeTag === 'IFRAME' ||
-        activeElement === composerRef.current;
-
-      if (!canRestoreFocus) return;
-      composerRef.current?.focus({ preventScroll: true });
-    };
-
-    [0, 100, 400, 900, 1600, 2600].forEach((delay) => {
-      const timer = window.setTimeout(restoreFocus, delay);
-      composerFocusTimerRefs.current.push(timer);
-    });
-  }, [isDesktopFullscreen, showDesktopView]);
 
   const streamBusy =
     streaming.isThinking ||
@@ -1025,12 +873,10 @@ export function SessionsPage() {
   const instancePickerLabel = activeInstance?.display_name || activeInstance?.name || activeInstanceName || 'Choose instance';
   const rightRailTabs = useMemo<Array<{ id: RightRailTab; label: string }>>(
     () => {
-      // Three primary tabs: Runtime (composite — Desktop/Terminals/Files),
-      // Agents (sub-agent tasks), Sessions (history). The previous five-tab
-      // strip is unflattened here: Desktop/Terminal/Files moved into the
-      // Runtime sub-segmented control rendered below the tab strip.
+      // Two primary tabs: Agents (sub-agent tasks) and Sessions (history). The
+      // Desktop/Terminals/Files runtime surfaces moved out into standalone
+      // workspace tabs, so the rail no longer hosts a composite Runtime tab.
       const tabs: Array<{ id: RightRailTab; label: string }> = [
-        { id: 'runtime', label: 'Runtime' },
         { id: 'sub_agents', label: 'Agents' },
         { id: 'sessions', label: 'Sessions' },
       ];
@@ -1043,26 +889,10 @@ export function SessionsPage() {
   );
   const rightRailActiveIndex = Math.max(0, rightRailTabs.findIndex((tab) => tab.id === rightRailTab));
 
+  // activeWorkbenchTab / activeWorkbenchDiff / activeWorkbenchDiffError /
+  // activeWorkbenchBaseRef / activeWorkbenchBaseRefOptions are provided by
+  // useSessionWorkbench (destructured above). Only the visibility flag is local.
   const workbenchVisible = workbenchTabs.length > 0;
-  const activeWorkbenchTab = useMemo(() => {
-    if (!workbenchTabs.length) return null;
-    if (!activeWorkbenchPath) return workbenchTabs[0];
-    return workbenchTabs.find((tab) => tab.path === activeWorkbenchPath) ?? workbenchTabs[0];
-  }, [workbenchTabs, activeWorkbenchPath]);
-  const activeWorkbenchDiff = activeWorkbenchTab ? workbenchDiffByPath[activeWorkbenchTab.path] ?? null : null;
-  const activeWorkbenchDiffError = activeWorkbenchTab ? workbenchDiffErrorByPath[activeWorkbenchTab.path] ?? null : null;
-  const activeWorkbenchGitRoots = activeWorkbenchTab ? workbenchGitRootsByPath[activeWorkbenchTab.path] ?? [] : [];
-  const activeWorkbenchViewMode = activeWorkbenchTab && workbenchShowDiffByPath[activeWorkbenchTab.path] ? 'diff' : 'content';
-  const activeWorkbenchViewerKey = activeWorkbenchTab
-    ? `${activeWorkbenchTab.path}:${activeWorkbenchViewMode}`
-    : 'none';
-  const activeWorkbenchBaseRef = activeWorkbenchTab
-    ? workbenchDiffBaseRefByPath[activeWorkbenchTab.path] ?? 'HEAD'
-    : 'HEAD';
-  const activeWorkbenchBaseRefOptions = useMemo(
-    () => (activeWorkbenchTab ? buildRuntimeDiffBaseRefOptions(activeWorkbenchGitRoots, activeWorkbenchBaseRef) : ['HEAD']),
-    [activeWorkbenchTab, activeWorkbenchGitRoots, activeWorkbenchBaseRef],
-  );
 
   const toolArgumentsByCallId = useMemo(() => buildToolArgumentsByCallId(messages), [messages]);
 
@@ -1277,41 +1107,10 @@ export function SessionsPage() {
     void fetchSessions({ autoSelectIfEmpty: true });
     void fetchModels();
     void fetchAgentModes();
-    void fetchLiveView();
-    void fetchRuntimeStatus();
+    // Live-view + runtime-status fetching (incl. the session-change re-fetch, the
+    // booting poll, and the desktop-visibility status refresh) is owned by
+    // `useSessionRuntimeStream`.
   }, [activeInstanceName]);
-
-  // Re-fetch live view when the active session changes
-  useEffect(() => {
-    setRuntimeBooting(true);
-    void fetchLiveView();
-  }, [activeSessionId]);
-
-  useEffect(() => {
-    if (!activeSessionId || !showDesktopView) return;
-    if (!runtimeBooting && liveView?.enabled && liveView.available) return;
-
-    let cancelled = false;
-    const refresh = async () => {
-      if (cancelled) return;
-      await fetchLiveView();
-    };
-    const interval = window.setInterval(() => {
-      void refresh();
-    }, 2000);
-
-    void refresh();
-
-    return () => {
-      cancelled = true;
-      window.clearInterval(interval);
-    };
-  }, [activeSessionId, showDesktopView, runtimeBooting, liveView?.enabled, liveView?.available]);
-
-  useEffect(() => {
-    if (!showDesktopView) return;
-    void fetchRuntimeStatus();
-  }, [showDesktopView, activeInstanceName]);
 
   // Poll sessions every 30s to pick up unread changes
   useEffect(() => {
@@ -1330,23 +1129,16 @@ export function SessionsPage() {
   }, []);
 
   useEffect(() => {
+    // Runtime/workbench state (files, repo changes, workbench tabs, diffs) is
+    // reset by `useSessionWorkbench` on session change; terminals + live view by
+    // `useSessionRuntimeStream`; the WS connection by the shared stream manager.
+    // This effect now only owns chat state (messages / context / tasks /
+    // streaming) and re-fetches the initial runtime file tree.
     if (!activeSessionId) {
       setMessages([]);
       setContextTokenEstimate(null);
       setContextTokenPercent(null);
       setTasks([]);
-      setRuntimeFiles(null);
-      setRuntimePath('');
-      setRuntimeRepoChangesByRoot({});
-      setRuntimeRepoChangesLoadingByRoot({});
-      setRuntimeExpandedGitDirs({});
-      setWorkbenchTabs([]);
-      setActiveWorkbenchPath(null);
-      setWorkbenchShowDiffByPath({});
-      setWorkbenchDiffByPath({});
-      setWorkbenchDiffErrorByPath({});
-      setWorkbenchDiffBaseRefByPath({});
-      setWorkbenchGitRootsByPath({});
       setStreaming(defaultStreamingState);
       shouldAutoScrollRef.current = true;
       lastScrollTopRef.current = 0;
@@ -1354,7 +1146,6 @@ export function SessionsPage() {
       oldestServerMessageIdRef.current = null;
       loadingOlderRef.current = false;
       setIsLoadingOlderMessages(false);
-      disconnectWs();
       return;
     }
 
@@ -1363,21 +1154,7 @@ export function SessionsPage() {
     setContextTokenEstimate(null);
     setContextTokenPercent(null);
     setTasks([]);
-    setRuntimeFiles(null);
-    setRuntimePath('');
-    setRuntimeRepoChangesByRoot({});
-    setRuntimeRepoChangesLoadingByRoot({});
-    setRuntimeExpandedGitDirs({});
-    setWorkbenchTabs([]);
-    setActiveWorkbenchPath(null);
-    setWorkbenchShowDiffByPath({});
-    setWorkbenchDiffByPath({});
-    setWorkbenchDiffErrorByPath({});
-    setWorkbenchDiffBaseRefByPath({});
-    setWorkbenchGitRootsByPath({});
     setStreaming(defaultStreamingState);
-    setActiveTerminals([]);
-    setFocusedTerminalId(null);
     setHasMoreMessages(false);
     oldestServerMessageIdRef.current = null;
     loadingOlderRef.current = false;
@@ -1389,13 +1166,18 @@ export function SessionsPage() {
     void loadMessages(activeSessionId);
     void fetchContextUsage(activeSessionId);
     void fetchTasks(activeSessionId);
-    void fetchRuntimeFiles(activeSessionId, '');
-    void connectWs(activeSessionId);
-
-    return () => {
-      disconnectWs();
-    };
+    // Seed the workbench file tree for this session. The standalone Files tab
+    // owns the live refresh loop; here we only need the initial listing so any
+    // open-file / diff actions from the chat workbench resolve against it.
+    void fetchRuntimeFiles('', { refreshGit: false });
   }, [activeSessionId]);
+
+  // Publish the page's selected session to the workspace-wide active-session
+  // store so the standalone Desktop / Terminal / Files tabs follow the session
+  // selected here.
+  useEffect(() => {
+    setActiveSession(activeSessionId);
+  }, [activeSessionId, setActiveSession]);
 
   useEffect(() => {
     if (!activeSessionId || !hasActiveSubAgentTasks) return;
@@ -1406,28 +1188,6 @@ export function SessionsPage() {
       window.clearInterval(timer);
     };
   }, [activeSessionId, hasActiveSubAgentTasks]);
-
-  useEffect(() => {
-    if (!activeSessionId || !showFilesView) return;
-    void fetchRuntimeFiles(activeSessionId, runtimePath, {
-      refreshGit: true,
-      silent: false,
-    });
-  }, [activeSessionId, showFilesView]);
-
-  useEffect(() => {
-    if (!activeSessionId || !showFilesView) return;
-    if (streaming.connection !== 'connected') return;
-    const timer = window.setInterval(() => {
-      void fetchRuntimeFiles(activeSessionId, runtimePath, {
-        refreshGit: true,
-        silent: true,
-      });
-    }, 3000);
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [activeSessionId, showFilesView, runtimePath, streaming.connection]);
 
   useLayoutEffect(() => {
     const el = scrollRef.current;
@@ -1707,144 +1467,19 @@ export function SessionsPage() {
     }
   }
 
-  async function fetchLiveView() {
-    const sid = activeSessionIdRef.current;
-    if (!sid) {
-      setLiveView(null);
-      setRuntimeBooting(false);
-      return;
-    }
-    try {
-      const query = new URLSearchParams({ session_id: sid, geometry: desktopResolution });
-      const payload = await api.get<RuntimeLiveView>(`/runtime/live-view?${query.toString()}`);
-      setLiveView(payload);
-      if (payload.enabled && payload.available) {
-        setRuntimeBooting(false);
-      } else if (payload.enabled) {
-        setRuntimeBooting(true);
-      } else {
-        setRuntimeBooting(false);
-      }
-    } catch {
-      setLiveView(null);
-    }
-  }
-
-  async function fetchRuntimeStatus() {
-    setRuntimeStatusLoading(true);
-    try {
-      const payload = await api.get<RuntimeStatusResponse>('/runtime/status');
-      setRuntimeStatus(payload);
-    } catch {
-      setRuntimeStatus(null);
-    } finally {
-      setRuntimeStatusLoading(false);
-    }
-  }
-
-  async function setDesktopResolution(geometry: string) {
-    if (isDesktopResolutionChanging || geometry === desktopResolution) return;
-    const sid = activeSessionIdRef.current;
-    if (!sid) return;
-    setDesktopResolutionState(geometry);
-    localStorage.setItem('sentinel-desktop-resolution', geometry);
-    setIsDesktopResolutionChanging(true);
-    setRuntimeBooting(true);
-    setDesktopLayoutNonce((value) => value + 1);
-    try {
-      const query = new URLSearchParams({ session_id: sid });
-      const payload = await api.post<RuntimeLiveView>(
-        `/runtime/live-view/resolution?${query.toString()}`,
-        { geometry },
-        { timeoutMs: 60_000 },
-      );
-      setLiveView(payload);
-      if (payload.enabled && payload.available) {
-        setRuntimeBooting(false);
-        setDesktopLayoutNonce((value) => value + 1);
-      } else {
-        toast.error(payload.reason || 'Desktop resolution change failed');
-      }
-    } catch {
-      toast.error('Failed to change desktop resolution');
-      setRuntimeBooting(false);
-    } finally {
-      setIsDesktopResolutionChanging(false);
-    }
-  }
-
-  async function resetBrowser() {
-    if (runtimeActionBusy) return;
-    const sid = activeSessionIdRef.current;
-    if (!sid) return;
-    setRuntimeActionBusy(true);
-    try {
-      await api.post<RuntimeActionResponse>(`/runtime/browser/reset?session_id=${sid}`, {});
-      toast.success('Browser reset');
-      await fetchLiveView();
-    } catch {
-      toast.error('Failed to reset browser');
-    } finally {
-      setRuntimeActionBusy(false);
-    }
-  }
-
-  async function restartDesktop() {
-    if (runtimeActionBusy) return;
-    const sid = activeSessionIdRef.current;
-    if (!sid) return;
-    setRuntimeActionBusy(true);
-    setRuntimeBooting(true);
-    setLiveView(null);
-    try {
-      await api.post<RuntimeActionResponse>(
-        `/runtime/desktop/restart?session_id=${sid}`,
-        { geometry: desktopResolution },
-        { timeoutMs: 60_000 },
-      );
-      toast.success('Desktop restarted');
-      await fetchLiveView();
-    } catch {
-      toast.error('Failed to restart desktop');
-      setRuntimeBooting(false);
-    } finally {
-      setRuntimeActionBusy(false);
-    }
-  }
-
-  async function wipeWorkspace() {
-    if (runtimeActionBusy) return;
-    const sid = activeSessionIdRef.current;
-    if (!sid) return;
-    const label = (activeSession?.title || 'Session').trim() || 'Session';
-    const workspaceSummary = await getSessionDeleteWorkspaceSummary(sid);
-    const confirmed = await confirmSessionDelete({
-      kind: 'workspace_wipe',
-      label,
-      topLevelEntries: workspaceSummary.topLevelEntries,
-    });
-    if (!confirmed) return;
-    setRuntimeActionBusy(true);
-    setRuntimeBooting(true);
-    setLiveView(null);
-    try {
-      await api.post<RuntimeActionResponse>(`/runtime/workspace/wipe?session_id=${sid}`, {}, { timeoutMs: 90_000 });
-      toast.success('Workspace wiped');
-      await fetchLiveView();
-      void fetchRuntimeFiles(sid, '');
-    } catch {
-      toast.error('Failed to wipe workspace');
-      setRuntimeBooting(false);
-    } finally {
-      setRuntimeActionBusy(false);
-    }
-  }
+  // The live-view / runtime-status fetches and the desktop-resolution and
+  // reset/restart/wipe runtime actions live with the standalone Desktop tab and
+  // the shared `useSessionRuntimeStream` hook now. SessionsPage keeps only
+  // `setLiveView` / `setRuntimeBooting` (used by resetSession + session-switch)
+  // through that hook.
 
   async function resetSession() {
     try {
       const previousId = activeSessionId;
-      // Disconnect WS and wipe messages before the API call to prevent stale events polluting the new session
-      disconnectWs();
+      // Null the active-session ref + wipe messages before the API call so the
+      // shared stream's guarded handler drops any in-flight events from the old
+      // session. Switching `activeSessionId` below re-subscribes the WS to the
+      // new session (and unsubscribes the old) via the runtime stream hook.
       activeSessionIdRef.current = null;
       setMessages([]);
       setStreaming(defaultStreamingState);
@@ -1995,290 +1630,10 @@ export function SessionsPage() {
     finally { setTasksLoading(false); }
   }
 
-  async function fetchRuntimeFiles(
-    sessionId: string,
-    path = '',
-    options?: { refreshGit?: boolean; silent?: boolean },
-  ) {
-    const silent = Boolean(options?.silent);
-    if (!silent) {
-      setRuntimeFilesLoading(true);
-    }
-    try {
-      const query = new URLSearchParams();
-      if (path.trim().length > 0) query.set('path', path.trim());
-      query.set('limit', '400');
-      const suffix = query.toString();
-      const payload = await api.get<SessionRuntimeFilesResponse>(`/sessions/${sessionId}/runtime/files${suffix ? `?${suffix}` : ''}`);
-      if (sessionId !== activeSessionIdRef.current) return;
-      setRuntimeFiles(payload);
-      setRuntimePath(payload.path || '');
-      if (options?.refreshGit ?? showFilesView) {
-        Object.keys(runtimeRepoChangesByRoot).forEach((rootPath) => {
-          void fetchRuntimeChangedFilesForRepo(sessionId, rootPath);
-        });
-      }
-    } catch (err) {
-      if (sessionId !== activeSessionIdRef.current) return;
-      // Directory no longer exists — walk up to the nearest valid parent
-      if ((err as { status?: number }).status === 404 && path) {
-        const parent = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
-        void fetchRuntimeFiles(sessionId, parent, options);
-        return;
-      }
-      // Preserve the last successful explorer tree on transient refresh failures.
-    } finally {
-      if (sessionId === activeSessionIdRef.current && !silent) {
-        setRuntimeFilesLoading(false);
-      }
-    }
-  }
-
-  async function loadRuntimeDirectoryEntries(path: string): Promise<SessionRuntimeFileEntry[]> {
-    if (!activeSessionId) return [];
-    const query = new URLSearchParams();
-    if (path.trim().length > 0) query.set('path', path.trim());
-    query.set('limit', '400');
-    const suffix = query.toString();
-    const payload = await api.get<SessionRuntimeFilesResponse>(
-      `/sessions/${activeSessionId}/runtime/files${suffix ? `?${suffix}` : ''}`,
-    );
-    if (activeSessionId !== activeSessionIdRef.current) return [];
-    return Array.isArray(payload?.entries) ? payload.entries : [];
-  }
-
-  async function downloadRuntimeEntry(entry: SessionRuntimeFileEntry) {
-    if (!activeSessionId) return;
-    try {
-      const { blob, filename } = await api.download(
-        `/sessions/${activeSessionId}/runtime/download?path=${encodeURIComponent(entry.path)}`,
-        { timeoutMs: 120_000 },
-      );
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
-      anchor.href = url;
-      anchor.download = filename || (entry.kind === 'directory' ? `${entry.name}.zip` : entry.name);
-      document.body.appendChild(anchor);
-      anchor.click();
-      document.body.removeChild(anchor);
-      URL.revokeObjectURL(url);
-    } catch {
-      toast.error(entry.kind === 'directory' ? 'Failed to download folder zip' : 'Failed to download file');
-    }
-  }
-
-  async function fetchRuntimeChangedFilesForRepo(
-    sessionId: string,
-    path: string,
-  ): Promise<SessionRuntimeGitChangedFilesResponse | null> {
-    setRuntimeRepoChangesLoadingByRoot((current) => ({ ...current, [path]: true }));
-    try {
-      const payload = await api.get<SessionRuntimeGitChangedFilesResponse>(
-        `/sessions/${sessionId}/runtime/git/changed?path=${encodeURIComponent(path)}&limit=200`,
-      );
-      if (sessionId !== activeSessionIdRef.current) return null;
-      setRuntimeRepoChangesByRoot((current) => ({ ...current, [path]: payload }));
-      return payload;
-    } catch {
-      if (sessionId !== activeSessionIdRef.current) return null;
-      setRuntimeRepoChangesByRoot((current) => ({ ...current, [path]: null }));
-      return null;
-    } finally {
-      if (sessionId === activeSessionIdRef.current) {
-        setRuntimeRepoChangesLoadingByRoot((current) => ({ ...current, [path]: false }));
-      }
-    }
-  }
-
-  async function openRuntimeDirectory(
-    path: string,
-    options?: { autoOpenFirstDiff?: boolean },
-  ) {
-    if (!activeSessionId) return;
-    const shouldAutoOpenFirstDiff = Boolean(options?.autoOpenFirstDiff);
-    await fetchRuntimeFiles(activeSessionId, path, {
-      refreshGit: !shouldAutoOpenFirstDiff,
-    });
-    if (!shouldAutoOpenFirstDiff) return;
-    const changed = await fetchRuntimeChangedFilesForRepo(activeSessionId, path);
-    const firstPath = changed?.entries?.[0]?.path;
-    if (!firstPath) return;
-    await openRuntimeFileDiff(firstPath);
-  }
-
-  async function openRuntimeFile(
-    path: string,
-    options?: { suppressErrorToast?: boolean },
-  ): Promise<boolean> {
-    if (!activeSessionId) return false;
-    setWorkbenchLoadingPath(path);
-    try {
-      const payload = await api.get<SessionRuntimeFilePreviewResponse>(
-        `/sessions/${activeSessionId}/runtime/file?path=${encodeURIComponent(path)}&max_bytes=32000`,
-      );
-      if (activeSessionId !== activeSessionIdRef.current) return false;
-      const nextTab: WorkbenchTab = {
-        path: payload.path,
-        name: payload.name,
-        size_bytes: payload.size_bytes,
-        modified_at: payload.modified_at,
-        content: payload.content,
-        truncated: payload.truncated,
-        max_bytes: payload.max_bytes,
-      };
-      setWorkbenchTabs((current) => {
-        const existing = current.find((tab) => tab.path === nextTab.path);
-        if (existing) {
-          return current.map((tab) => (tab.path === nextTab.path ? nextTab : tab));
-        }
-        return [...current, nextTab];
-      });
-      setActiveWorkbenchPath(nextTab.path);
-      setWorkbenchDiffBaseRefByPath((current) =>
-        current[nextTab.path] ? current : { ...current, [nextTab.path]: 'HEAD' },
-      );
-      setWorkbenchDiffErrorByPath((current) => ({ ...current, [nextTab.path]: null }));
-      setWorkbenchShowDiffByPath((current) =>
-        Object.prototype.hasOwnProperty.call(current, nextTab.path)
-          ? current
-          : { ...current, [nextTab.path]: false },
-      );
-      void fetchRuntimeGitRoots(activeSessionId, nextTab.path);
-      return true;
-    } catch {
-      if (!options?.suppressErrorToast) {
-        toast.error('Failed to open runtime file');
-      }
-      return false;
-    } finally {
-      if (activeSessionId === activeSessionIdRef.current) {
-        setWorkbenchLoadingPath((current) => (current === path ? null : current));
-      }
-    }
-  }
-
-  function ensureWorkbenchTab(path: string) {
-    const name = path.split('/').pop() || path;
-    setWorkbenchTabs((current) => {
-      if (current.some((tab) => tab.path === path)) return current;
-      return [
-        ...current,
-        {
-          path,
-          name,
-          size_bytes: 0,
-          modified_at: null,
-          content: '',
-          truncated: false,
-          max_bytes: 0,
-        },
-      ];
-    });
-    setActiveWorkbenchPath(path);
-    setWorkbenchDiffBaseRefByPath((current) =>
-      current[path] ? current : { ...current, [path]: 'HEAD' },
-    );
-    setWorkbenchDiffErrorByPath((current) => ({ ...current, [path]: null }));
-  }
-
-  async function openRuntimeFileDiff(path: string) {
-    if (!activeSessionId) return;
-    const opened = await openRuntimeFile(path, { suppressErrorToast: true });
-    if (!opened) {
-      ensureWorkbenchTab(path);
-    }
-    setWorkbenchShowDiffByPath((current) => ({ ...current, [path]: true }));
-    void fetchRuntimeGitDiff(activeSessionId, path);
-  }
-
-  function closeWorkbenchTab(path: string) {
-    setWorkbenchTabs((current) => {
-      const targetIndex = current.findIndex((tab) => tab.path === path);
-      const next = current.filter((tab) => tab.path !== path);
-      setActiveWorkbenchPath((previous) => {
-        if (previous !== path) return previous;
-        if (!next.length) return null;
-        const fallbackIndex = Math.min(Math.max(targetIndex - 1, 0), next.length - 1);
-        return next[fallbackIndex]?.path ?? next[next.length - 1].path;
-      });
-      return next;
-    });
-    setWorkbenchShowDiffByPath((current) => {
-      const next = { ...current };
-      delete next[path];
-      return next;
-    });
-    setWorkbenchDiffByPath((current) => {
-      const next = { ...current };
-      delete next[path];
-      return next;
-    });
-    setWorkbenchDiffErrorByPath((current) => {
-      const next = { ...current };
-      delete next[path];
-      return next;
-    });
-    setWorkbenchDiffBaseRefByPath((current) => {
-      const next = { ...current };
-      delete next[path];
-      return next;
-    });
-    setWorkbenchGitRootsByPath((current) => {
-      const next = { ...current };
-      delete next[path];
-      return next;
-    });
-    setWorkbenchLoadingPath((current) => (current === path ? null : current));
-    setWorkbenchDiffLoadingPath((current) => (current === path ? null : current));
-  }
-
-  async function fetchRuntimeGitRoots(sessionId: string, path: string) {
-    try {
-      const payload = await api.get<SessionRuntimeGitRootsResponse>(
-        `/sessions/${sessionId}/runtime/git/roots?path=${encodeURIComponent(path)}&limit=200`,
-      );
-      if (sessionId !== activeSessionIdRef.current) return;
-      setWorkbenchGitRootsByPath((current) => ({ ...current, [path]: payload.roots || [] }));
-    } catch {
-      if (sessionId !== activeSessionIdRef.current) return;
-      setWorkbenchGitRootsByPath((current) => ({ ...current, [path]: [] }));
-    }
-  }
-
-  async function fetchRuntimeGitDiff(
-    sessionId: string,
-    path: string,
-    options?: { baseRef?: string },
-  ) {
-    const baseRefRaw = options?.baseRef ?? workbenchDiffBaseRefByPath[path];
-    const baseRef = (typeof baseRefRaw === 'string' && baseRefRaw.trim().length > 0) ? baseRefRaw.trim() : 'HEAD';
-    setWorkbenchDiffLoadingPath(path);
-    setWorkbenchDiffErrorByPath((current) => ({ ...current, [path]: null }));
-    try {
-      const query = new URLSearchParams();
-      query.set('path', path);
-      query.set('base_ref', baseRef);
-      query.set('staged', 'false');
-      query.set('context_lines', '3');
-      query.set('max_bytes', '120000');
-      const payload = await api.get<SessionRuntimeGitDiffResponse>(
-        `/sessions/${sessionId}/runtime/git/diff?${query.toString()}`,
-      );
-      if (sessionId !== activeSessionIdRef.current) return;
-      setWorkbenchDiffByPath((current) => ({ ...current, [path]: payload }));
-      setWorkbenchShowDiffByPath((current) => ({ ...current, [path]: true }));
-      if (!workbenchGitRootsByPath[path]?.length) {
-        void fetchRuntimeGitRoots(sessionId, path);
-      }
-    } catch (error) {
-      const detail = error instanceof Error ? error.message : 'Failed to load git diff';
-      setWorkbenchDiffErrorByPath((current) => ({ ...current, [path]: detail }));
-    } finally {
-      if (sessionId === activeSessionIdRef.current) {
-        setWorkbenchDiffLoadingPath((current) => (current === path ? null : current));
-      }
-    }
-  }
+  // Files / workbench actions (fetchRuntimeFiles, loadRuntimeDirectoryEntries,
+  // downloadRuntimeEntry, fetchChangedFilesForRepo, openRuntimeFile,
+  // openRuntimeDirectory, openRuntimeFileDiff, closeWorkbenchTab,
+  // fetchRuntimeGitDiff, ...) now live in `useSessionWorkbench`.
 
   async function terminateTask(taskId: string) {
     if (!activeSessionId || isTerminatingTask) return;
@@ -2457,70 +1812,10 @@ export function SessionsPage() {
     }
   }, [updatePersistedMessageApproval, updateStreamingCallApproval]);
 
-  // WebSocket Logic
-  function disconnectWs() {
-    intentionalCloseRef.current = true;
-    wsInstanceRef.current += 1;
-    if (reconnectTimerRef.current) {
-      window.clearTimeout(reconnectTimerRef.current);
-      reconnectTimerRef.current = null;
-    }
-    if (wsRef.current) {
-      wsRef.current.onopen = null;
-      wsRef.current.onmessage = null;
-      wsRef.current.onclose = null;
-      wsRef.current.close();
-      wsRef.current = null;
-    }
-    setStreaming((current) => ({ ...current, connection: 'disconnected' }));
-  }
-
-  async function connectWs(sessionId: string) {
-    disconnectWs();
-    intentionalCloseRef.current = false;
-
-    setStreaming((current) => ({
-      ...current,
-      connection: reconnectAttemptsRef.current > 0 ? 'reconnecting' : 'connecting',
-    }));
-
-    const instanceId = ++wsInstanceRef.current;
-    if (!activeInstanceName) {
-      return;
-    }
-    const ws = new WebSocket(`${wsSessionsBaseUrl(activeInstanceName)}/${sessionId}/stream`);
-    wsRef.current = ws;
-
-    ws.onopen = () => {
-      if (instanceId !== wsInstanceRef.current || ws !== wsRef.current) return;
-      reconnectAttemptsRef.current = 0;
-      setStreaming((current) => ({ ...current, connection: 'connected' }));
-    };
-
-    ws.onmessage = (event) => {
-      if (instanceId !== wsInstanceRef.current || ws !== wsRef.current) return;
-      try {
-        const payload = JSON.parse(event.data) as WsEvent;
-        onStreamEvent(sessionId, payload);
-      } catch { /* ignore */ }
-    };
-
-    ws.onclose = () => {
-      if (instanceId !== wsInstanceRef.current || ws !== wsRef.current) return;
-      wsRef.current = null;
-      if (!intentionalCloseRef.current) scheduleReconnect(sessionId);
-    };
-  }
-
-  function scheduleReconnect(sessionId: string) {
-    reconnectAttemptsRef.current += 1;
-    if (reconnectAttemptsRef.current > 8) {
-      toast.error('Realtime stream disconnected');
-      return;
-    }
-    const delay = Math.min(2 ** reconnectAttemptsRef.current, 20);
-    reconnectTimerRef.current = window.setTimeout(() => connectWs(sessionId), delay * 1000);
-  }
+  // WebSocket connection + reconnect are owned by the shared, ref-counted stream
+  // manager (`session-stream.ts`) and consumed via `useSessionRuntimeStream`.
+  // `onStreamEvent` below is the chat-side handler, wired in as the hook's
+  // `onEvent` tap so chat + runtime share ONE socket per session.
 
   function markLatestUserMessageRetryable(rawError: string) {
     const latestUserMessage = [...messagesRef.current].reverse().find((message) => message.role === 'user');
@@ -2629,6 +1924,9 @@ export function SessionsPage() {
 
     switch (event.type) {
       case 'connected':
+        // Terminal population from `event.terminals` is handled by
+        // `useSessionRuntimeStream`; here we only own the chat-side payload
+        // (context budget + message history).
         if (typeof event.context_token_budget === 'number' && Number.isFinite(event.context_token_budget) && event.context_token_budget > 0) {
           setContextTokenBudget(Math.floor(event.context_token_budget));
         }
@@ -2641,89 +1939,10 @@ export function SessionsPage() {
           oldestServerMessageIdRef.current = next.length > 0 ? next[0].id : null;
           return next;
         });
-        if (Array.isArray(event.terminals)) {
-          // Initial pill population: server may have terminals alive across a
-          // reload or backend restart. We replace state entirely rather than
-          // merge so stale terminals from the previous session don't linger.
-          const incomingTerminals = event.terminals
-            .map((raw) => {
-              if (!raw || typeof raw !== 'object') return null;
-              const value = raw as Record<string, unknown>;
-              const id = typeof value.terminal_id === 'string' ? value.terminal_id : null;
-              if (!id) return null;
-              return {
-                id,
-                label: typeof value.label === 'string' ? value.label : null,
-                createdBy: value.created_by === 'user' ? 'user' : 'agent',
-                createdAt: typeof value.created_at === 'number' ? value.created_at : Date.now() / 1000,
-                auto: Boolean(value.auto),
-                busy: false,
-                lastCommand: typeof value.last_command === 'string' ? value.last_command : null,
-              } as ActiveTerminal;
-            })
-            .filter((item): item is ActiveTerminal => item !== null);
-          setActiveTerminals(incomingTerminals);
-        }
         break;
-      case 'terminal_opened': {
-        const id = typeof event.terminal_id === 'string' ? event.terminal_id : null;
-        if (!id) break;
-        const label = typeof event.label === 'string' ? event.label : null;
-        const createdBy = event.created_by === 'user' ? 'user' : 'agent';
-        const auto = Boolean(event.auto);
-        // Capture "was the pill row empty before this event?" before we mutate
-        // it. We auto-focus the Terminals sub-view only on the FIRST terminal
-        // of a session, so the user isn't yanked off Files/Desktop every time
-        // the agent spins up another shell.
-        let wasFirstTerminal = false;
-        setActiveTerminals((current) => {
-          if (current.some((t) => t.id === id)) {
-            return current.map((t) => (t.id === id ? { ...t, label: t.label || label } : t));
-          }
-          wasFirstTerminal = current.length === 0;
-          return [
-            ...current,
-            { id, label, createdBy, createdAt: Date.now() / 1000, auto, busy: false, lastCommand: null },
-          ];
-        });
-        // Auto-focus rule: only flip to the Terminals sub-view if we're
-        // already on the Runtime tab AND this is the first terminal AND the
-        // user hasn't manually picked a sub-view in the last 4s. Anything
-        // else would be surprise UI motion. Cross-tab activity (Agents /
-        // Sessions) never steals focus.
-        if (
-          wasFirstTerminal
-          && rightRailTab === 'runtime'
-          && Date.now() - lastRuntimeViewIntentRef.current > 4_000
-        ) {
-          setRuntimeView('terminals');
-        }
-        break;
-      }
-      case 'terminal_closed': {
-        const id = typeof event.terminal_id === 'string' ? event.terminal_id : null;
-        if (!id) break;
-        setActiveTerminals((current) => current.filter((t) => t.id !== id));
-        setFocusedTerminalId((current) => (current === id ? null : current));
-        break;
-      }
-      case 'terminal_busy': {
-        const id = typeof event.terminal_id === 'string' ? event.terminal_id : null;
-        if (!id) break;
-        const busy = Boolean(event.busy);
-        // The same event carries the most-recent command/cwd whenever the
-        // backend has them — that's how the pill tooltip + rail header stay
-        // in sync with what the terminal is actually doing.
-        const lastCommand = typeof event.last_command === 'string' ? event.last_command : undefined;
-        setActiveTerminals((current) =>
-          current.map((t) =>
-            t.id === id
-              ? { ...t, busy, lastCommand: lastCommand !== undefined ? lastCommand : t.lastCommand }
-              : t,
-          ),
-        );
-        break;
-      }
+      // terminal_opened / terminal_closed / terminal_busy and runtime_ready are
+      // handled by useSessionRuntimeStream. SessionsPage does not opt into the
+      // hook's onFirstTerminalOpened callback, so no terminal auto-focus here.
       case 'message_ack':
         setMessages((current) => {
           const messageId = (event.message_id as string | undefined)?.trim();
@@ -2970,10 +2189,11 @@ export function SessionsPage() {
             toolNameForRefresh === 'git' ||
             toolNameForRefresh === 'str_replace_editor'
           ) {
-            if (showFilesView) {
-              setRuntimeFilesRefreshKey((current) => current + 1);
-              void fetchRuntimeFiles(sessionId, runtimePath);
-            }
+            // Keep the chat workbench's file tree + repo changes fresh when a
+            // file-mutating tool completes. The standalone Files tab runs its
+            // own poll; this only feeds the workbench panel hosted here.
+            bumpRuntimeFilesRefreshKey();
+            void fetchRuntimeFiles(runtimePath, { refreshGit: true });
           }
         }
         setStreaming((current) => {
@@ -3038,29 +2258,9 @@ export function SessionsPage() {
         setStreaming((current) => ({ ...current, isCompactingContext: false }));
         toast.error((event.error as string) || 'Auto-compaction failed');
         break;
-      case 'runtime_ready':
-        // noVNC may need a moment after the container reports ready — retry a few times
-        void (async () => {
-          for (let attempt = 0; attempt < 6; attempt++) {
-            await new Promise((r) => setTimeout(r, 2000));
-            const sid = activeSessionIdRef.current;
-            if (!sid) break;
-            try {
-              const query = new URLSearchParams({ session_id: sid, geometry: desktopResolution });
-              const payload = await api.get<RuntimeLiveView>(`/runtime/live-view?${query.toString()}`);
-              setLiveView(payload);
-              if (payload.enabled && payload.available) {
-                setRuntimeBooting(false);
-                return;
-              }
-            } catch { /* retry */ }
-          }
-          const sid = activeSessionIdRef.current;
-          if (!sid) {
-            setRuntimeBooting(false);
-          }
-        })();
-        break;
+      // runtime_ready is handled by useSessionRuntimeStream (it re-fetches the
+      // live view a few times until noVNC is reachable, clearing the booting
+      // flag).
       case 'done': {
         const stopReason = event.stop_reason as string | undefined;
         if (stopReason === 'tool_use') {
@@ -3192,7 +2392,7 @@ export function SessionsPage() {
     const content = composer.trim();
     if ((!content && composerAttachments.length === 0) || streamBusy || !activeSessionId) return;
 
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
+    if (isStreamOpen()) {
       setRetryCandidate(null);
       // Prepend time context if conversation has been idle for >30 minutes
       const lastMsg = messages.at(-1);
@@ -3201,16 +2401,14 @@ export function SessionsPage() {
       const idleNote = idleMs > 30 * 60 * 1000
         ? `[Resuming after ${Math.round(idleMs / 60000)} min — current time: ${now}]\n\n`
         : '';
-      wsRef.current.send(
-        JSON.stringify({
-          type: 'message',
-          content: idleNote + content,
-          attachments: composerAttachments,
-          tier: selectedTier,
-          max_iterations: maxIterations,
-          agent_mode: selectedAgentMode ?? undefined,
-        })
-      );
+      sendStreamMessage({
+        type: 'message',
+        content: idleNote + content,
+        attachments: composerAttachments,
+        tier: selectedTier,
+        max_iterations: maxIterations,
+        agent_mode: selectedAgentMode ?? undefined,
+      });
       setComposer('');
       setComposerAttachments([]);
       shouldAutoScrollRef.current = true;
@@ -3238,25 +2436,12 @@ export function SessionsPage() {
     finally { setIsStopping(false); }
   }
 
-  // Switch to the Runtime tab and pick a sub-view in one call. Used by
-  // anything that wants to focus a specific runtime surface — terminal
-  // pill clicks, "Open terminal" links inside tool cards, the segmented
-  // control buttons themselves. Recording the intent timestamp lets the
-  // auto-focus rule (see terminal_opened WS handler) know to back off
-  // when the user has just steered the view manually.
-  function openRuntimeView(view: RuntimeView) {
-    lastRuntimeViewIntentRef.current = Date.now();
-    setRightRailTab('runtime');
-    setRuntimeView(view);
-  }
-
   // Optimistically drops the pill so the UI reacts immediately, then asks the
   // backend to kill the tmux session. The authoritative `terminal_closed` WS
   // event will also fire and is idempotent against the optimistic update.
   async function closeTerminal(terminalId: string) {
     if (!activeSessionId) return;
-    setActiveTerminals((current) => current.filter((t) => t.id !== terminalId));
-    setFocusedTerminalId((current) => (current === terminalId ? null : current));
+    dropTerminal(terminalId);
     try {
       await api.delete(
         `/sessions/${activeSessionId}/terminals/${encodeURIComponent(terminalId)}`,
@@ -3306,9 +2491,9 @@ export function SessionsPage() {
           subtitle={activeSession ? `ID: ${activeSession.id}` : 'Operator Workspace'}
           contentClassName="h-full !p-0 overflow-hidden"
           hideSidebar={mode === 'solo'}
-          hideHeader={mode === 'solo' || isDesktopFullscreen}
+          hideHeader={mode === 'solo'}
           actions={
-            mode === 'advanced' && !isDesktopFullscreen ? (
+            mode === 'advanced' ? (
               <div className="flex min-w-0 items-center gap-2">
                 <div ref={sessionDropdownRef} className="order-5 relative z-[200] hidden min-w-0 sm:block">
                   <button
@@ -3794,7 +2979,8 @@ export function SessionsPage() {
                           onResolveApproval={resolveApprovalInline}
                           resolvingApprovalKey={resolvingApprovalKey}
                           onOpenTerminal={(tid) => {
-                            openRuntimeView('terminals');
+                            // Focus the terminal in the shared runtime state; the
+                            // standalone Terminal tab follows it.
                             setFocusedTerminalId(tid);
                           }}
                         />
@@ -3811,7 +2997,8 @@ export function SessionsPage() {
                           onResolveApproval={resolveApprovalInline}
                           resolvingApprovalKey={resolvingApprovalKey}
                           onOpenTerminal={(tid) => {
-                            openRuntimeView('terminals');
+                            // Focus the terminal in the shared runtime state; the
+                            // standalone Terminal tab follows it.
                             setFocusedTerminalId(tid);
                           }}
                         />
@@ -3826,7 +3013,8 @@ export function SessionsPage() {
                           onResolveApproval={resolveApprovalInline}
                           resolvingApprovalKey={resolvingApprovalKey}
                           onOpenTerminal={(tid) => {
-                            openRuntimeView('terminals');
+                            // Focus the terminal in the shared runtime state; the
+                            // standalone Terminal tab follows it.
                             setFocusedTerminalId(tid);
                           }}
                         />
@@ -3878,7 +3066,7 @@ export function SessionsPage() {
                           {activeTerminals.length > 0 ? (
                             <div className="flex flex-wrap items-center justify-center gap-1.5">
                               {activeTerminals.map((terminal) => {
-                                const isFocused = focusedTerminalId === terminal.id && showTerminalsView;
+                                const isFocused = focusedTerminalId === terminal.id;
                                 // Label is derived from terminal_id: '0' → "main",
                                 // 'auto-xxx' / 'bg-…' → first command summary, anything
                                 // else → the agent's chosen name verbatim. Stable
@@ -3899,7 +3087,8 @@ export function SessionsPage() {
                                     <button
                                       type="button"
                                       onClick={() => {
-                                        openRuntimeView('terminals');
+                                        // Focus this terminal in the shared runtime
+                                        // state; the standalone Terminal tab follows.
                                         setFocusedTerminalId(terminal.id);
                                       }}
                                       className={`inline-flex items-center gap-1.5 ${closable ? 'pl-3 pr-2' : 'px-3'} h-7 text-[10px] font-bold uppercase tracking-wider active:scale-95`}
@@ -4040,13 +3229,7 @@ export function SessionsPage() {
             </div>
           </main>
 
-          {workbenchVisible && !isDesktopFullscreen ? (
-            // While the desktop fullscreen overlay is up, the Workbench panel
-            // would otherwise sit on top of it (its `relative z-30` ends up in
-            // a different stacking context than DesktopPreview's `fixed
-            // z-[1000]`, so the simple z compare doesn't win). Unmounting it
-            // for the duration of the fullscreen state is cleaner than
-            // wrestling with stacking contexts and avoids paint thrash.
+          {workbenchVisible ? (
             <>
               <div
                 className="order-4 relative hidden xl:block w-0 shrink-0"
@@ -4062,17 +3245,7 @@ export function SessionsPage() {
                 activeTabPath={activeWorkbenchPath}
                 onTabClick={(path) => setActiveWorkbenchPath(path)}
                 onTabClose={closeWorkbenchTab}
-                onCloseAll={() => {
-                  setWorkbenchTabs([]);
-                  setActiveWorkbenchPath(null);
-                  setWorkbenchShowDiffByPath({});
-                  setWorkbenchDiffByPath({});
-                  setWorkbenchDiffErrorByPath({});
-                  setWorkbenchDiffBaseRefByPath({});
-                  setWorkbenchGitRootsByPath({});
-                  setWorkbenchLoadingPath(null);
-                  setWorkbenchDiffLoadingPath(null);
-                }}
+                onCloseAll={closeAllWorkbenchTabs}
                 showExplorer={false}
                 explorerEntries={runtimeFiles?.entries || []}
                 currentExplorerPath={runtimePath}
@@ -4084,56 +3257,27 @@ export function SessionsPage() {
                 onExplorerDirectoryToggle={(entry, expanded) => {
                   if (!activeSessionId || !entry.is_git_root) return;
                   if (!expanded) {
-                    setRuntimeRepoChangesByRoot((current) => {
-                      const next = { ...current };
-                      delete next[entry.path];
-                      return next;
-                    });
-                    setRuntimeRepoChangesLoadingByRoot((current) => {
-                      const next = { ...current };
-                      delete next[entry.path];
-                      return next;
-                    });
-                    setRuntimeExpandedGitDirs((current) => {
-                      const next = { ...current };
-                      Object.keys(next).forEach((key) => {
-                        if (key === entry.path || key.startsWith(`${entry.path}/`)) delete next[key];
-                      });
-                      return next;
-                    });
+                    forgetRepoRoot(entry.path);
                     return;
                   }
-                  void fetchRuntimeChangedFilesForRepo(activeSessionId, entry.path);
+                  void fetchChangedFilesForRepo(entry.path);
                 }}
                 repoChangesSections={runtimeRepoChangeSections}
                 expandedGitDirs={runtimeExpandedGitDirs}
-                onToggleGitDir={(path) => {
-                  setRuntimeExpandedGitDirs((current) => ({ ...current, [path]: !(current[path] ?? false) }));
-                }}
+                onToggleGitDir={toggleGitDir}
                 onGitFileClick={(path) => void openRuntimeFileDiff(path)}
                 diffMode={activeWorkbenchTab ? workbenchShowDiffByPath[activeWorkbenchTab.path] ?? false : false}
                 setDiffMode={(enabled) => {
                   if (!activeWorkbenchTab) return;
-                  setWorkbenchShowDiffByPath((current) => ({ ...current, [activeWorkbenchTab.path]: enabled }));
-                  if (enabled && activeSessionId) {
-                    void fetchRuntimeGitDiff(activeSessionId, activeWorkbenchTab.path);
-                  }
+                  setShowDiffForPath(activeWorkbenchTab.path, enabled);
                 }}
                 diffContent={activeWorkbenchDiff}
-                diffLoading={workbenchDiffLoadingPath === activeWorkbenchTab?.path}
+                diffLoading={activeWorkbenchDiffLoading}
                 diffError={activeWorkbenchDiffError}
                 diffBaseRef={activeWorkbenchBaseRef}
                 onDiffBaseRefChange={(ref) => {
                   if (!activeWorkbenchTab) return;
-                  setWorkbenchDiffBaseRefByPath((current) => ({
-                    ...current,
-                    [activeWorkbenchTab.path]: ref,
-                  }));
-                  if (activeSessionId && workbenchShowDiffByPath[activeWorkbenchTab.path]) {
-                    void fetchRuntimeGitDiff(activeSessionId, activeWorkbenchTab.path, {
-                      baseRef: ref,
-                    });
-                  }
+                  setDiffBaseRefForPath(activeWorkbenchTab.path, ref);
                 }}
                 diffBaseRefOptions={activeWorkbenchBaseRefOptions}
                 width={workbenchWidth}
@@ -4189,528 +3333,6 @@ export function SessionsPage() {
               </div>
             </div>
 
-            {/* Runtime sub-segmented control: Desktop / Terminals / Files.
-                Only rendered when the Runtime tab is active. Matches the
-                primary tab strip's pill styling so the two reads as a
-                hierarchy without screaming for attention. */}
-            {isRuntimeTab ? (
-              <div className="px-3 pb-2">
-                {/* Flex (not grid) layout: each pill sizes to content, so a
-                    label + icon + badge never overflow its cell. The sliding
-                    indicator is positioned by measured offsetLeft/Width via
-                    a useLayoutEffect above — that's what keeps it locked to
-                    the active button regardless of rail width or badge count.
-                    Buttons get `flex-1 min-w-0` so they share remaining
-                    space evenly when the strip is wider than the natural
-                    content; on narrow widths they shrink toward content. */}
-                <div
-                  ref={runtimeStripRef}
-                  className="relative flex items-stretch gap-1 rounded-full border border-[color:var(--border-subtle)] p-1 bg-[color:var(--surface-2)]"
-                >
-                  {runtimeIndicator ? (
-                    <div
-                      aria-hidden
-                      className="pointer-events-none absolute top-1 bottom-1 rounded-full bg-[color:var(--surface-0)] shadow-sm transition-[left,width] duration-300 ease-out"
-                      style={{ left: runtimeIndicator.left, width: runtimeIndicator.width }}
-                    />
-                  ) : null}
-                  {([
-                    { id: 'desktop' as const, label: 'Desktop', Icon: Globe },
-                    { id: 'terminals' as const, label: 'Terminals', Icon: Terminal },
-                    { id: 'files' as const, label: 'Files', Icon: Folder },
-                  ]).map(({ id, label, Icon }) => {
-                    const active = runtimeView === id;
-                    const badge = id === 'terminals' && activeTerminals.length > 0
-                      ? activeTerminals.length
-                      : null;
-                    return (
-                      <button
-                        key={id}
-                        ref={(el) => { runtimeTabRefs.current[id] = el; }}
-                        type="button"
-                        onClick={() => openRuntimeView(id)}
-                        className={`relative z-10 flex-1 min-w-0 inline-flex items-center justify-center gap-1.5 h-7 px-2.5 rounded-full text-[10px] font-bold uppercase tracking-wider transition-colors duration-200 active:scale-95 ${
-                          active
-                            ? 'text-[color:var(--text-primary)]'
-                            : 'text-[color:var(--text-muted)] hover:text-[color:var(--text-secondary)]'
-                        }`}
-                        title={label}
-                      >
-                        <Icon size={11} className="shrink-0" />
-                        <span className="truncate">{label}</span>
-                        {badge !== null ? (
-                          <span className="shrink-0 inline-flex items-center justify-center min-w-[16px] h-[15px] px-1 rounded-full bg-sky-500/20 text-sky-300 text-[9px] font-bold tracking-normal leading-none">
-                            {badge}
-                          </span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : null}
-
-            {showDesktopView ? (
-              <div className="flex-1 min-h-0 flex flex-col">
-                <div className={`relative flex items-center justify-between p-3 border-b border-[color:var(--border-subtle)] ${
-                  isDesktopFullscreen ? 'z-10' : 'z-[110]'
-                }`}>
-                  <div className="flex items-center gap-2">
-                    <Globe size={15} className="text-sky-500" />
-                    <span className="text-[10px] font-bold uppercase tracking-widest text-[color:var(--text-muted)]">
-                      Interactive View
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <select
-                      value={desktopResolution}
-                      onChange={(event) => void setDesktopResolution(event.target.value)}
-                      disabled={isDesktopResolutionChanging || isDesktopRuntimeStarting}
-                      className="h-7 max-w-[126px] rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-2 font-mono text-[10px] font-bold text-[color:var(--text-secondary)] outline-none transition-colors hover:bg-[color:var(--surface-2)] disabled:opacity-50"
-                      title="Desktop resolution"
-                    >
-                      {DESKTOP_RESOLUTION_PRESETS.map((preset) => (
-                        <option key={preset.value} value={preset.value}>
-                          {preset.label}
-                        </option>
-                      ))}
-                    </select>
-                    {/* Reset dropdown */}
-                    <div className={`relative ${isDesktopFullscreen ? 'z-10' : 'z-[120]'}`} ref={resetMenuRef}>
-                      <button
-                        onClick={() => setResetMenuOpen((o) => !o)}
-                        disabled={runtimeActionBusy}
-                        className="p-1.5 rounded-md hover:bg-[color:var(--surface-2)] transition-colors text-[color:var(--text-muted)] disabled:opacity-50"
-                        title="Runtime actions"
-                      >
-                        {runtimeActionBusy
-                          ? <RotateCcw size={14} className="animate-spin" />
-                          : <Settings2 size={14} />}
-                      </button>
-                      {resetMenuOpen && (
-                        <div
-                          className={`absolute right-0 top-full mt-1 w-48 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] shadow-xl overflow-hidden ${
-                            isDesktopFullscreen ? 'z-10' : 'z-[130]'
-                          }`}
-                          onMouseLeave={() => setResetMenuOpen(false)}
-                        >
-                          <button
-                            className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left text-[11px] font-medium text-[color:var(--text-primary)] hover:bg-[color:var(--surface-2)] transition-colors"
-                            onClick={() => { setResetMenuOpen(false); void resetBrowser(); }}
-                          >
-                            <RotateCcw size={13} className="text-rose-400 shrink-0" />
-                            <div>
-                              <div className="font-semibold">Reset Browser</div>
-                              <div className="text-[9px] text-[color:var(--text-muted)]">Wipe Chrome profile</div>
-                            </div>
-                          </button>
-                          <div className="h-px bg-[color:var(--border-subtle)]" />
-                          <button
-                            className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left text-[11px] font-medium text-[color:var(--text-primary)] hover:bg-[color:var(--surface-2)] transition-colors"
-                            onClick={() => { setResetMenuOpen(false); void restartDesktop(); }}
-                          >
-                            <RefreshCw size={13} className="text-amber-400 shrink-0" />
-                            <div>
-                              <div className="font-semibold">Restart Desktop</div>
-                              <div className="text-[9px] text-[color:var(--text-muted)]">Restart VNC session</div>
-                            </div>
-                          </button>
-                          <div className="h-px bg-[color:var(--border-subtle)]" />
-                          <button
-                            className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left text-[11px] font-medium text-rose-300 hover:bg-rose-500/10 transition-colors"
-                            onClick={() => { setResetMenuOpen(false); void wipeWorkspace(); }}
-                          >
-                            <Trash2 size={13} className="text-rose-400 shrink-0" />
-                            <div>
-                              <div className="font-semibold">Wipe Workspace</div>
-                              <div className="text-[9px] text-[color:var(--text-muted)]">Delete session files</div>
-                            </div>
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                    <button
-                      onClick={() => setIsDesktopFullscreen(true)}
-                      className="p-1.5 rounded-md hover:bg-[color:var(--surface-2)] transition-colors text-sky-500"
-                      title="Open fullscreen"
-                    >
-                      <Expand size={14} />
-                    </button>
-                  </div>
-                </div>
-                <div className="flex-1 min-h-0 overflow-y-auto">
-                  <div className="relative w-full aspect-[16/10] overflow-hidden border-b border-[color:var(--border-subtle)] bg-black">
-                    <DesktopPreview
-                      url={liveView?.enabled && liveView?.available ? liveView.url : null}
-                      wsUrl={liveView?.enabled && liveView?.available ? liveView.ws_url : null}
-                      isFullscreen={isDesktopFullscreen}
-                      onClose={() => setIsDesktopFullscreen(false)}
-                      isBooting={isDesktopRuntimeStarting && !(liveView?.enabled && liveView?.available)}
-                      layoutKey={`${mode}:${desktopLayoutNonce}:${liveView?.geometry ?? desktopResolution}`}
-                      onFrameLoad={handleDesktopFrameLoad}
-                      onInteract={handleDesktopInteract}
-                    />
-                  </div>
-
-                  <div className="p-3 space-y-4">
-                    <section>
-                      <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-muted)] mb-2.5 px-1">Desktop Status</div>
-                      <div className="space-y-1.5">
-                        <div className="flex items-center justify-between p-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)]/50 transition-all hover:bg-[color:var(--surface-1)]">
-                          <span className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--text-secondary)]">Connection</span>
-                          <div className="flex items-center gap-2">
-                            {liveView?.enabled && liveView.available ? (
-                              <>
-                                <div className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.4)]" />
-                                <span className="text-[10px] font-mono font-bold text-emerald-500">CONNECTED</span>
-                              </>
-                            ) : isDesktopRuntimeStarting ? (
-                              <>
-                                <div className="h-1.5 w-1.5 rounded-full bg-sky-400 animate-pulse" />
-                                <span className="text-[10px] font-mono font-bold text-sky-400">STARTING</span>
-                              </>
-                            ) : (
-                              <>
-                                <div className="h-1.5 w-1.5 rounded-full bg-rose-500" />
-                                <span className="text-[10px] font-mono font-bold text-rose-500 uppercase">
-                                  {liveView?.enabled ? 'UNREACHABLE' : 'DISABLED'}
-                                </span>
-                              </>
-                            )}
-                          </div>
-                        </div>
-                        <div className="p-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)]/50 transition-all hover:bg-[color:var(--surface-1)]">
-                          <div className="flex items-center justify-between gap-3">
-                            <span className="text-[9px] font-bold uppercase tracking-widest text-[color:var(--text-muted)] shrink-0">Stream URL</span>
-                            <div className="flex-1 min-w-0 font-mono text-[10px] text-[color:var(--text-secondary)] truncate text-right">
-                              {liveView?.ws_url || liveView?.url || '—'}
-                            </div>
-                          </div>
-                          {liveView?.reason && (
-                            <div className="mt-1 text-[9px] font-medium text-amber-500/80 leading-relaxed italic text-right truncate">
-                              {liveView.reason}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </section>
-
-                    {(() => {
-                      const overall = runtimeStatus?.status;
-                      const allChecks = runtimeStatus?.checks ?? [];
-                      const failed = allChecks.filter((c) => c.status === 'fail' || c.status === 'warn');
-                      const requiredFailures = failed.filter((c) => c.required);
-                      const optionalWarnings = failed.filter((c) => !c.required);
-                      const passed = allChecks.filter((c) => c.status === 'pass');
-                      const skipped = allChecks.filter((c) => c.status === 'skip');
-                      const totalPassMs = passed.reduce((sum, c) => sum + (c.duration_ms ?? 0), 0);
-                      const primaryFailure = requiredFailures[0] ?? null;
-                      const remainingRequiredFailures = requiredFailures.slice(1);
-                      const suppressPassedRollup = overall === 'unreachable' || overall === 'failed';
-                      type CheckEntry = (typeof allChecks)[number];
-
-                      const heroIcon =
-                        overall === 'ready' ? <CheckCircle2 size={16} className="text-emerald-400 shrink-0 mt-0.5" /> :
-                        overall === 'degraded' ? <AlertCircle size={16} className="text-amber-400 shrink-0 mt-0.5" /> :
-                        overall === 'unreachable' || overall === 'failed' ? <XCircle size={16} className="text-rose-500 shrink-0 mt-0.5" /> :
-                        overall === 'not_configured' ? <HelpCircle size={16} className="text-[color:var(--text-muted)] shrink-0 mt-0.5" /> :
-                        <Loader2 size={16} className="text-[color:var(--text-muted)] animate-spin shrink-0 mt-0.5" />;
-
-                      const heroLabel =
-                        overall === 'ready' ? 'Ready' :
-                        overall === 'degraded' ? 'Degraded' :
-                        overall === 'unreachable' ? 'Unreachable' :
-                        overall === 'failed' ? 'Failed' :
-                        overall === 'not_configured' ? 'Not configured' :
-                        runtimeStatusLoading ? 'Checking…' : 'Unknown';
-
-                      const heroBorder =
-                        overall === 'ready' ? 'border-emerald-500/30 bg-emerald-500/5' :
-                        overall === 'degraded' ? 'border-amber-500/30 bg-amber-500/5' :
-                        overall === 'unreachable' || overall === 'failed' ? 'border-rose-500/30 bg-rose-500/5' :
-                        'border-[color:var(--border-subtle)] bg-[color:var(--surface-1)]/50';
-
-                      const targetLine = runtimeStatus?.runtime
-                        ? [
-                            runtimeStatus.runtime.name,
-                            runtimeStatus.runtime.host && `${runtimeStatus.runtime.host}:${runtimeStatus.runtime.port ?? 22}`,
-                          ].filter(Boolean).join(' · ')
-                        : null;
-
-                      const settingsHref = instanceRouteFromPath(location.pathname, 'settings');
-                      const looksLikeCommand = (text: string) =>
-                        /^(sudo |mkdir |chown |chmod |systemctl |service |brew |apt |apt-get |yum |dnf |pacman |scp |ssh |docker |npm |pip |uv |cargo |go )/.test(text.trim());
-
-                      const renderFixCallout = (check: CheckEntry) => {
-                        const isConfigFailure = check.id.startsWith('config_');
-                        const hintIsCommand = check.hint ? looksLikeCommand(check.hint) : false;
-                        if (!check.hint && !isConfigFailure) return null;
-                        return (
-                          <div className="rounded-md border-l-2 border-amber-500/50 bg-[color:var(--surface-1)]/40 pl-2 pr-1.5 py-1.5 space-y-1.5">
-                            {check.hint && hintIsCommand ? (
-                              <div className="flex items-start gap-1.5">
-                                <code className="flex-1 font-mono text-[10px] text-[color:var(--text-primary)] break-all leading-snug">{check.hint}</code>
-                                <button
-                                  type="button"
-                                  onClick={() => { navigator.clipboard.writeText(check.hint ?? ''); toast.success('Copied'); }}
-                                  className="shrink-0 p-0.5 rounded text-[color:var(--text-muted)] hover:text-[color:var(--accent-solid)] transition-colors"
-                                  title="Copy to clipboard"
-                                >
-                                  <Copy size={10} />
-                                </button>
-                              </div>
-                            ) : check.hint ? (
-                              <div className="text-[10px] leading-snug text-[color:var(--text-secondary)]">{check.hint}</div>
-                            ) : null}
-                            {isConfigFailure && (
-                              <button
-                                type="button"
-                                onClick={() => navigate(settingsHref)}
-                                className="inline-flex items-center gap-1 text-[9px] font-bold uppercase tracking-widest text-[color:var(--accent-solid)] hover:opacity-70 transition-opacity"
-                              >
-                                Open Settings <ExternalLink size={9} />
-                              </button>
-                            )}
-                          </div>
-                        );
-                      };
-
-                      return (
-                        <section className="space-y-2">
-                          {/* Hero card — absorbs the primary required failure when one exists */}
-                          <div className={`rounded-lg border px-2.5 py-2 ${heroBorder}`}>
-                            <div className="flex items-start gap-2">
-                              {heroIcon}
-                              <div className="flex-1 min-w-0 space-y-1">
-                                <div className="flex items-center gap-2 flex-wrap">
-                                  <span className="text-[12px] font-bold text-[color:var(--text-primary)]">{heroLabel}</span>
-                                  {targetLine && (
-                                    <span className="text-[10px] font-mono text-[color:var(--text-muted)] truncate">{targetLine}</span>
-                                  )}
-                                </div>
-                                {primaryFailure ? (
-                                  <>
-                                    <div className="text-[10px] text-[color:var(--text-secondary)] leading-snug">
-                                      <span className="font-semibold text-[color:var(--text-primary)]">{primaryFailure.label}</span> failed
-                                      {typeof primaryFailure.duration_ms === 'number' && primaryFailure.duration_ms >= 500 && (
-                                        <span className="font-mono text-[color:var(--text-muted)]"> · {primaryFailure.duration_ms}ms</span>
-                                      )}
-                                    </div>
-                                    {primaryFailure.detail && (
-                                      <div className="font-mono text-[10px] leading-snug text-[color:var(--text-secondary)] break-words">
-                                        {primaryFailure.detail}
-                                      </div>
-                                    )}
-                                    {renderFixCallout(primaryFailure)}
-                                  </>
-                                ) : (
-                                  (runtimeStatus?.summary || runtimeStatusLoading) && (
-                                    <div className="text-[10px] text-[color:var(--text-secondary)] leading-snug">
-                                      {runtimeStatus?.summary ?? 'Checking runtime status…'}
-                                    </div>
-                                  )
-                                )}
-                              </div>
-                              <button
-                                type="button"
-                                onClick={() => void fetchRuntimeStatus()}
-                                disabled={runtimeStatusLoading}
-                                className="inline-flex h-5 w-5 items-center justify-center rounded text-[color:var(--text-muted)] hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] disabled:opacity-50 shrink-0"
-                                title="Refresh runtime diagnostics"
-                              >
-                                <RefreshCw size={11} className={runtimeStatusLoading ? 'animate-spin' : ''} />
-                              </button>
-                            </div>
-                          </div>
-
-                          {/* Additional required failures, if any (rare — usually there's just one). */}
-                          {remainingRequiredFailures.length > 0 && (
-                            <div className="space-y-1.5">
-                              {remainingRequiredFailures.map((check) => (
-                                <div key={check.id} className="rounded-lg border border-rose-500/30 bg-rose-500/5 px-2.5 py-2">
-                                  <div className="flex items-start gap-2">
-                                    <XCircle size={13} className="text-rose-500 shrink-0 mt-0.5" />
-                                    <div className="min-w-0 flex-1 space-y-1">
-                                      <div className="text-[11px] font-bold text-[color:var(--text-primary)]">{check.label}</div>
-                                      {check.detail && (
-                                        <div className="font-mono text-[10px] leading-snug text-[color:var(--text-secondary)] break-words">{check.detail}</div>
-                                      )}
-                                      {renderFixCallout(check)}
-                                    </div>
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          )}
-
-                          {/* Optional warnings — collapsed roll-up */}
-                          {optionalWarnings.length > 0 && (
-                            <div className="space-y-1">
-                              <button
-                                type="button"
-                                onClick={() => setShowOptionalRuntimeWarnings((v) => !v)}
-                                className="w-full flex items-center justify-between gap-2 px-2.5 py-1.5 rounded-lg border border-amber-500/20 bg-amber-500/5 hover:bg-amber-500/10 transition-all text-left"
-                              >
-                                <div className="flex items-center gap-1.5 min-w-0">
-                                  <AlertCircle size={11} className="text-amber-400 shrink-0" />
-                                  <span className="text-[10px] font-medium text-[color:var(--text-secondary)]">
-                                    {optionalWarnings.length} optional capabilit{optionalWarnings.length === 1 ? 'y' : 'ies'} missing
-                                  </span>
-                                </div>
-                                <ChevronDown size={11} className={`text-[color:var(--text-muted)] shrink-0 transition-transform ${showOptionalRuntimeWarnings ? 'rotate-180' : ''}`} />
-                              </button>
-                              {showOptionalRuntimeWarnings && (
-                                <div className="space-y-1 px-2 py-1.5 rounded-lg bg-[color:var(--surface-1)]/30">
-                                  {optionalWarnings.map((check) => (
-                                    <div key={check.id} className="flex items-start gap-1.5 py-0.5">
-                                      <div className="h-1 w-1 rounded-full bg-amber-400 shrink-0 mt-1.5" />
-                                      <div className="min-w-0 flex-1">
-                                        <div className="flex items-baseline gap-1.5">
-                                          <span className="text-[10px] font-semibold text-[color:var(--text-secondary)]">{check.label}</span>
-                                          {check.detail && <span className="text-[9px] text-[color:var(--text-muted)] font-mono truncate">{check.detail}</span>}
-                                        </div>
-                                        {check.hint && (
-                                          <div className="text-[9px] text-[color:var(--text-muted)] leading-snug">{check.hint}</div>
-                                        )}
-                                      </div>
-                                    </div>
-                                  ))}
-                                </div>
-                              )}
-                            </div>
-                          )}
-
-                          {/* Passing checks collapsed — hidden when the runtime is unreachable/failed */}
-                          {passed.length > 0 && !suppressPassedRollup && (
-                            <div className="space-y-1">
-                              <button
-                                type="button"
-                                onClick={() => setShowPassingRuntimeChecks((v) => !v)}
-                                className="w-full flex items-center justify-between gap-2 px-2.5 py-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)]/40 hover:bg-[color:var(--surface-1)] transition-all text-left"
-                              >
-                                <div className="flex items-center gap-1.5 min-w-0">
-                                  <CheckCircle2 size={11} className="text-emerald-400 shrink-0" />
-                                  <span className="text-[10px] font-medium text-[color:var(--text-secondary)]">
-                                    {passed.length} check{passed.length === 1 ? '' : 's'} passed
-                                    {totalPassMs > 0 ? ` · ${totalPassMs}ms` : ''}
-                                  </span>
-                                </div>
-                                <ChevronDown size={11} className={`text-[color:var(--text-muted)] shrink-0 transition-transform ${showPassingRuntimeChecks ? 'rotate-180' : ''}`} />
-                              </button>
-                              {showPassingRuntimeChecks && (
-                                <div className="space-y-0.5 px-2 py-1.5 rounded-lg bg-[color:var(--surface-1)]/30">
-                                  {passed.map((check) => (
-                                    <div key={check.id} className="flex items-center gap-1.5 py-0.5">
-                                      <div className="h-1 w-1 rounded-full bg-emerald-500 shrink-0" />
-                                      <span className="text-[10px] text-[color:var(--text-secondary)] flex-1 min-w-0 truncate">{check.label}</span>
-                                      {typeof check.duration_ms === 'number' && check.duration_ms >= 100 && (
-                                        <span className="font-mono text-[9px] text-[color:var(--text-muted)] shrink-0">{check.duration_ms}ms</span>
-                                      )}
-                                    </div>
-                                  ))}
-                                  {skipped.map((check) => (
-                                    <div key={check.id} className="flex items-center gap-1.5 py-0.5 opacity-50">
-                                      <div className="h-1 w-1 rounded-full bg-[color:var(--text-muted)] shrink-0" />
-                                      <span className="text-[10px] text-[color:var(--text-muted)] flex-1 min-w-0 truncate">{check.label} (skipped)</span>
-                                    </div>
-                                  ))}
-                                </div>
-                              )}
-                            </div>
-                          )}
-
-                          {/* Empty / loading states */}
-                          {!runtimeStatus && runtimeStatusLoading && allChecks.length === 0 && (
-                            <div className="py-3 text-center text-[10px] text-[color:var(--text-muted)] opacity-60">
-                              Checking runtime…
-                            </div>
-                          )}
-                          {!runtimeStatus && !runtimeStatusLoading && (
-                            <div className="py-3 text-center text-[10px] text-[color:var(--text-muted)] opacity-40">
-                              No diagnostics yet.
-                            </div>
-                          )}
-
-                          {/* Footer metadata */}
-                          {runtimeStatus?.runtime && (runtimeStatus.runtime.username || runtimeStatus.runtime.workspaces_dir) && (
-                            <div className="pt-0.5 px-1 space-y-0 text-[9px] text-[color:var(--text-muted)] font-mono">
-                              <div className="truncate">
-                                {[
-                                  runtimeStatus.os !== 'unknown' ? runtimeStatus.os : null,
-                                  runtimeStatus.sandbox !== 'unknown' && runtimeStatus.sandbox !== 'unavailable' ? `${runtimeStatus.sandbox} sandbox` : null,
-                                  runtimeStatus.runtime.username && runtimeStatus.runtime.host
-                                    ? `${runtimeStatus.runtime.username}@${runtimeStatus.runtime.host}:${runtimeStatus.runtime.port ?? 22}`
-                                    : null,
-                                ].filter(Boolean).join(' · ')}
-                              </div>
-                              {runtimeStatus.runtime.workspaces_dir && (
-                                <div className="truncate">{runtimeStatus.runtime.workspaces_dir}</div>
-                              )}
-                            </div>
-                          )}
-                        </section>
-                      );
-                    })()}
-                  </div>
-                </div>
-              </div>
-            ) : null}
-
-            {showTerminalsView ? (
-              <div className="flex-1 min-h-0 flex flex-col">
-                {activeTerminals.length > 1 ? (
-                  <div className="flex items-center gap-1 overflow-x-auto custom-scrollbar px-3 py-2 border-b border-[color:var(--border-subtle)]">
-                    {activeTerminals.map((terminal) => {
-                      const display = getTerminalLabel(terminal.id, terminal.lastCommand ?? terminal.label);
-                      const isFocused = (focusedTerminalId ?? activeTerminals[0]?.id) === terminal.id;
-                      return (
-                        <button
-                          key={terminal.id}
-                          type="button"
-                          onClick={() => setFocusedTerminalId(terminal.id)}
-                          className={`shrink-0 inline-flex items-center gap-1 rounded-md px-2 h-6 text-[10px] font-medium transition-colors ${
-                            isFocused
-                              ? 'bg-sky-500/20 text-sky-300'
-                              : 'text-[color:var(--text-muted)] hover:bg-[color:var(--surface-2)]'
-                          }`}
-                          title={display}
-                        >
-                          <span className="max-w-[120px] truncate">{display}</span>
-                          {terminal.busy ? <Loader2 size={9} className="animate-spin" /> : null}
-                        </button>
-                      );
-                    })}
-                  </div>
-                ) : null}
-                <div className="flex-1 min-h-0">
-                  {activeSessionId && (focusedTerminalId ?? activeTerminals[0]?.id) ? (
-                    // Keyed on the (session, terminal) pair so React tears down
-                    // and re-creates the xterm + WS when the user switches tabs;
-                    // sharing state across terminals would mix scrollback.
-                    <TerminalPreview
-                      key={`${activeSessionId}:${focusedTerminalId ?? activeTerminals[0].id}`}
-                      sessionId={activeSessionId}
-                      terminalId={focusedTerminalId ?? activeTerminals[0].id}
-                      instanceName={activeInstanceName ?? ''}
-                    />
-                  ) : (
-                    // Empty state mirrors the Agents tab's idle treatment —
-                    // muted icon block + short subtitle — so the runtime sub
-                    // views feel like a family even when empty.
-                    <div className="flex flex-col items-center justify-center h-full gap-3 px-6 text-center text-[color:var(--text-muted)] opacity-60">
-                      <div className="p-3 rounded-2xl bg-[color:var(--surface-2)]">
-                        <Terminal size={24} strokeWidth={1} />
-                      </div>
-                      <p className="text-[10px] font-medium uppercase tracking-widest">No terminals open</p>
-                      <p className="text-[10px] leading-relaxed max-w-[220px]">
-                        The agent will open one here when it runs a shell command.
-                      </p>
-                    </div>
-                  )}
-                </div>
-              </div>
-            ) : null}
-
             {rightRailTab === 'sub_agents' ? (
               <div className="flex-1 min-h-0 flex flex-col">
                 <div className="flex-1 overflow-y-auto p-3 space-y-2.5 custom-scrollbar">
@@ -4761,51 +3383,6 @@ export function SessionsPage() {
                     Spawn Sub-Agent
                   </button>
                 </div>
-              </div>
-            ) : null}
-
-            {showFilesView ? (
-              <div className="flex-1 min-h-0 flex flex-col">
-                <WorkbenchExplorerPane
-                  showTitle={false}
-                  currentPath={runtimePath}
-                  explorerLoading={runtimeFilesLoading}
-                  explorerEntries={runtimeFiles?.entries || []}
-                  onExplorerFileClick={(entry) => void openRuntimeFile(entry.path)}
-                  onExplorerDownload={(entry) => void downloadRuntimeEntry(entry)}
-                  loadExplorerDirectory={loadRuntimeDirectoryEntries}
-                  explorerRefreshKey={runtimeFilesRefreshKey}
-                  onExplorerDirectoryToggle={(entry, expanded) => {
-                    if (!activeSessionId || !entry.is_git_root) return;
-                    if (!expanded) {
-                      setRuntimeRepoChangesByRoot((current) => {
-                        const next = { ...current };
-                        delete next[entry.path];
-                        return next;
-                      });
-                      setRuntimeRepoChangesLoadingByRoot((current) => {
-                        const next = { ...current };
-                        delete next[entry.path];
-                        return next;
-                      });
-                      setRuntimeExpandedGitDirs((current) => {
-                        const next = { ...current };
-                        Object.keys(next).forEach((key) => {
-                          if (key === entry.path || key.startsWith(`${entry.path}/`)) delete next[key];
-                        });
-                        return next;
-                      });
-                      return;
-                    }
-                    void fetchRuntimeChangedFilesForRepo(activeSessionId, entry.path);
-                  }}
-                  repoChangesSections={runtimeRepoChangeSections}
-                  expandedGitDirs={runtimeExpandedGitDirs}
-                  onToggleGitDir={(path) => {
-                    setRuntimeExpandedGitDirs((current) => ({ ...current, [path]: !(current[path] ?? false) }));
-                  }}
-                  onGitFileClick={(path) => void openRuntimeFileDiff(path)}
-                />
               </div>
             ) : null}
 

--- a/apps/frontend/sentinel/src/pages/SessionsPage.tsx
+++ b/apps/frontend/sentinel/src/pages/SessionsPage.tsx
@@ -62,6 +62,7 @@ import {
   type ApprovalRef,
 } from '../lib/approvals';
 import { api } from '../lib/api';
+import { useInstanceName, useWorkspaceMode } from '../lib/workspace-context';
 import { instanceRouteFromPath } from '../lib/routes';
 import { getSessionDeleteWorkspaceSummary } from '../lib/sessionDeletion';
 import {
@@ -606,15 +607,23 @@ function StreamToolCard({
 export function SessionsPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const workspaceMode = useWorkspaceMode();
   const { id: routeSessionId } = useParams<{ id: string }>();
   const sessionRoute = useCallback(
     (sessionId?: string | null) => instanceRouteFromPath(location.pathname, sessionId ? `sessions/${sessionId}` : 'sessions'),
     [location.pathname],
   );
-  const activeInstanceName = useMemo(() => {
-    const match = location.pathname.match(/^\/instances\/([^/]+)/);
-    return match?.[1] ? decodeURIComponent(match[1]) : null;
-  }, [location.pathname]);
+  const instanceName = useInstanceName();
+  const activeInstanceName = instanceName ?? null;
+  // In a tiling pane the page is not the active route, so route-driven session
+  // selection would hijack the global URL. Keep selection local instead.
+  const selectSession = useCallback(
+    (sessionId: string | null, options?: { replace?: boolean }) => {
+      if (workspaceMode) return;
+      navigate(sessionRoute(sessionId), options);
+    },
+    [workspaceMode, navigate, sessionRoute],
+  );
 
   const [instances, setInstances] = useState<SentinelInstance[]>([]);
   const [sessions, setSessions] = useState<Session[]>([]);
@@ -1180,8 +1189,9 @@ export function SessionsPage() {
 
   const onInstanceClick = useCallback((instanceName: string) => {
     if (!instanceName || instanceName === activeInstanceName) return;
-    navigate(`/instances/${encodeURIComponent(instanceName)}/sessions`);
-  }, [activeInstanceName, navigate]);
+    const dest = workspaceMode ? 'workspace' : 'sessions';
+    navigate(`/instances/${encodeURIComponent(instanceName)}/${dest}`);
+  }, [activeInstanceName, navigate, workspaceMode]);
 
   const onSessionClick = useCallback((id: string) => {
     const previousId = activeSessionIdRef.current;
@@ -1190,9 +1200,9 @@ export function SessionsPage() {
     }
     setRuntimeBooting(true);
     setActiveSessionId(id);
-    navigate(sessionRoute(id));
+    selectSession(id);
     markSessionRead(id);
-  }, [markSessionRead, navigate, sessionRoute]);
+  }, [markSessionRead, selectSession]);
 
   const startResizing = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -1241,11 +1251,13 @@ export function SessionsPage() {
 
   // Effects
   useEffect(() => {
+    // In a tiling pane the route id is not the selected session; local state owns it.
+    if (workspaceMode) return;
     if (routeSessionId && routeSessionId !== activeSessionId) {
       setRuntimeBooting(true);
       setActiveSessionId(routeSessionId);
     }
-  }, [routeSessionId, activeSessionId]);
+  }, [workspaceMode, routeSessionId, activeSessionId]);
 
   useEffect(() => {
     setSelectedSessionIds((current) => current.filter((id) => sessions.some((session) => session.id === id)));
@@ -1467,7 +1479,7 @@ export function SessionsPage() {
       if (autoSelectIfEmpty && !activeSessionIdRef.current) {
         setActiveSessionId(defaultSession.id);
         activeSessionIdRef.current = defaultSession.id;
-        navigate(sessionRoute(defaultSession.id), { replace: true });
+        selectSession(defaultSession.id, { replace: true });
       }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to load sessions');
@@ -1515,11 +1527,7 @@ export function SessionsPage() {
             ? remaining.find((item) => item.id === defaultSessionId)?.id
             : null) ?? remaining[0]?.id ?? null;
         setActiveSessionId(fallbackId);
-        if (fallbackId) {
-          navigate(sessionRoute(fallbackId), { replace: true });
-        } else {
-          navigate(sessionRoute(), { replace: true });
-        }
+        selectSession(fallbackId, { replace: true });
       }
       toast.success('Session deleted');
     } catch (error) {
@@ -1543,7 +1551,7 @@ export function SessionsPage() {
         ),
       );
       setActiveSessionId(updated.id);
-      navigate(sessionRoute(updated.id));
+      selectSession(updated.id);
       toast.success('Main session updated');
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to set main session');
@@ -1638,11 +1646,7 @@ export function SessionsPage() {
               ? remaining.find((session) => session.id === defaultSessionId)?.id
               : null) ?? remaining[0]?.id ?? null;
           setActiveSessionId(fallbackId);
-          if (fallbackId) {
-            navigate(sessionRoute(fallbackId), { replace: true });
-          } else {
-            navigate(sessionRoute(), { replace: true });
-          }
+          selectSession(fallbackId, { replace: true });
         }
       }
 
@@ -1852,7 +1856,7 @@ export function SessionsPage() {
       setActiveSessionId(fresh.id);
       setRuntimeBooting(true);
       setLiveView(null);
-      navigate(sessionRoute(fresh.id), { replace: true });
+      selectSession(fresh.id, { replace: true });
       toast.success('New session started. Memories preserved.');
     } catch {
       toast.error('Failed to reset session');

--- a/apps/frontend/sentinel/src/pages/SettingsPage.tsx
+++ b/apps/frontend/sentinel/src/pages/SettingsPage.tsx
@@ -13,7 +13,8 @@ import { Panel } from '../components/ui/Panel';
 import { StatusChip } from '../components/ui/StatusChip';
 import { APP_VERSION } from '../lib/env';
 import { api, requestBlob } from '../lib/api';
-import { instanceRouteFromPath } from '../lib/routes';
+import { useInstanceName } from '../lib/workspace-context';
+import { instanceRoute, instanceRouteFromPath } from '../lib/routes';
 import { useAuthStore } from '../store/auth-store';
 import type {
   Runtime,
@@ -404,9 +405,8 @@ export function SettingsPage() {
     }
   }
 
-  const instanceName = location.pathname.match(/^\/instances\/([^/]+)/)?.[1]
-    ? decodeURIComponent(location.pathname.match(/^\/instances\/([^/]+)/)?.[1] || '')
-    : null;
+  // Context-first so the page works inside a tiling pane (not the active route).
+  const instanceName = useInstanceName() ?? null;
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -1267,7 +1267,7 @@ export function SettingsPage() {
             <div className="space-y-3">
               {isAdmin ? (
                 <RouterLink
-                  to={instanceRouteFromPath(location.pathname, 'settings/admin')}
+                  to={instanceName ? instanceRoute(instanceName, 'settings/admin') : instanceRouteFromPath(location.pathname, 'settings/admin')}
                   className="flex items-center justify-between p-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-0)] hover:bg-[color:var(--surface-1)] hover:border-[color:var(--border-strong)] transition-all group"
                 >
                   <div className="flex items-center gap-3">

--- a/apps/frontend/sentinel/src/pages/TriggerDetailPage.tsx
+++ b/apps/frontend/sentinel/src/pages/TriggerDetailPage.tsx
@@ -247,19 +247,19 @@ export function TriggerDetailPage() {
       subtitle={trigger ? `Type: ${trigger.type} • Protocol: ${trigger.action_type}` : 'Analyzing telemetry...'}
       actions={
         <div className="flex items-center gap-2">
-          <button onClick={() => navigate(instanceRouteFromPath(location.pathname, 'triggers'))} className="btn-secondary h-9 px-3 text-xs gap-2">
+          <button onClick={() => navigate(instanceRouteFromPath(location.pathname, 'triggers'))} className="inline-flex h-7 items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-3 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm">
             <ArrowLeft size={14} /> Back
           </button>
-          <div className="h-6 w-px bg-[color:var(--border-subtle)] mx-1" />
-          <button onClick={() => void loadAll(true)} className="p-2 text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)]">
-            <RefreshCw size={18} className={loading ? 'animate-spin' : ''} />
+          <button onClick={() => void loadAll(true)} aria-label="Refresh" className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm">
+            <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
           </button>
-          <button 
-            onClick={deleteTrigger} 
+          <button
+            onClick={deleteTrigger}
             disabled={!trigger}
-            className="p-2 rounded-md hover:bg-rose-500/10 text-rose-500 transition-colors"
+            aria-label="Delete"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] text-rose-500 transition-all hover:bg-rose-500/10 hover:border-rose-500/30 active:scale-95 shadow-sm disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            <Trash2 size={18} />
+            <Trash2 size={14} />
           </button>
         </div>
       }

--- a/apps/frontend/sentinel/src/pages/TriggersPage.tsx
+++ b/apps/frontend/sentinel/src/pages/TriggersPage.tsx
@@ -487,15 +487,14 @@ export function TriggersPage() {
       subtitle="Autonomous Event Scheduling & Webhooks"
       actions={
         <div className="flex items-center gap-2">
-          <button onClick={() => void loadData()} className="p-2 text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)] transition-colors active:scale-95">
-            <RefreshCw size={18} className={loading ? 'animate-spin' : ''} />
+          <button onClick={() => void loadData()} aria-label="Refresh" className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm">
+            <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
           </button>
-          <div className="h-4 w-px bg-[color:var(--border-subtle)] mx-1" />
-          <button 
-           onClick={openCreateModal} 
-           className="inline-flex h-9 items-center gap-2.5 rounded-full border border-transparent bg-[color:var(--accent-solid)] px-4 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--app-bg)] transition-all hover:opacity-90 active:scale-95 shadow-md shadow-black/5"
+          <button
+           onClick={openCreateModal}
+           className="inline-flex h-7 items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-1)] px-3 text-[10px] font-bold uppercase tracking-[0.1em] text-[color:var(--text-secondary)] transition-all hover:bg-[color:var(--surface-2)] hover:text-[color:var(--text-primary)] hover:border-[color:var(--border-strong)] active:scale-95 shadow-sm"
          >
-            <Plus size={14} />
+            <Plus size={14} className="text-emerald-500/80" />
             New Automation
           </button>
         </div>

--- a/apps/frontend/sentinel/src/pages/TriggersPage.tsx
+++ b/apps/frontend/sentinel/src/pages/TriggersPage.tsx
@@ -24,6 +24,7 @@ import { StatusChip } from '../components/ui/StatusChip';
 import { Toggle } from '../components/ui/Toggle';
 import { api } from '../lib/api';
 import { formatCompactDate } from '../lib/format';
+import { useWorkspaceMode } from '../lib/workspace-context';
 import { instanceRouteFromPath } from '../lib/routes';
 import type {
   Session,
@@ -153,6 +154,7 @@ function formatNextRunRelative(nextFireAt: string | null, nowMs: number): string
 export function TriggersPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const workspaceMode = useWorkspaceMode();
   const [triggers, setTriggers] = useState<Trigger[]>([]);
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
@@ -408,7 +410,7 @@ export function TriggersPage() {
       } else {
         toast.success('Trigger invoked');
       }
-      if (result.resolved_session_id) {
+      if (result.resolved_session_id && !workspaceMode) {
         navigate(instanceRouteFromPath(location.pathname, `sessions/${result.resolved_session_id}`));
         return;
       }
@@ -437,7 +439,7 @@ export function TriggersPage() {
       } else {
         toast.success('Trigger invoked');
       }
-      if (result.resolved_session_id) {
+      if (result.resolved_session_id && !workspaceMode) {
         navigate(instanceRouteFromPath(location.pathname, `sessions/${result.resolved_session_id}`));
         return;
       }

--- a/apps/frontend/sentinel/src/store/active-session-store.ts
+++ b/apps/frontend/sentinel/src/store/active-session-store.ts
@@ -1,0 +1,60 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+/**
+ * Active-session store
+ * --------------------
+ * Workspace-wide "which session is the user looking at" pointer. SessionsPage
+ * owns selection today (URL / local state) and publishes it here via
+ * {@link useActiveSessionStore}'s `setActiveSession`. Standalone runtime tabs
+ * (Desktop / Terminal / Files panes in the tiling workspace) read it so they
+ * know which session's runtime to show without re-implementing selection.
+ *
+ * Kept intentionally tiny: a single id plus a setter. The persisted value lets a
+ * freshly opened runtime tab pick up the last-selected session across reloads;
+ * SessionsPage still re-asserts the value on mount so the two never drift.
+ */
+
+const STORAGE_KEY = 'sentinel.active-session';
+
+export interface ActiveSessionState {
+  /** The workspace-wide selected session id, or null when none is selected. */
+  activeSessionId: string | null;
+  /** Set (or clear) the workspace-wide selected session. */
+  setActiveSession: (sessionId: string | null) => void;
+}
+
+export const useActiveSessionStore = create<ActiveSessionState>()(
+  persist(
+    (set) => ({
+      activeSessionId: null,
+      setActiveSession: (sessionId) =>
+        set((state) => (state.activeSessionId === sessionId ? state : { activeSessionId: sessionId })),
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ activeSessionId: state.activeSessionId }),
+    },
+  ),
+);
+
+// --- selectors ---------------------------------------------------------------
+// Both return primitives (string | null), so no useShallow is required. Any
+// future selector that returns an array/object MUST wrap with useShallow to
+// avoid the useSyncExternalStore "getSnapshot should be cached" loop.
+
+/** Hook: the workspace-wide active session id (null when none). */
+export function useActiveSessionId(): string | null {
+  return useActiveSessionStore((state) => state.activeSessionId);
+}
+
+/** Hook: the stable `setActiveSession` action. */
+export function useSetActiveSession(): (sessionId: string | null) => void {
+  return useActiveSessionStore((state) => state.setActiveSession);
+}
+
+/** Non-reactive read for imperative call sites. */
+export function getActiveSessionId(): string | null {
+  return useActiveSessionStore.getState().activeSessionId;
+}

--- a/apps/frontend/sentinel/src/store/pane-actions-store.ts
+++ b/apps/frontend/sentinel/src/store/pane-actions-store.ts
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react';
+import { create } from 'zustand';
+
+/**
+ * Pane-actions store
+ * ------------------
+ * dockview renders a pane's tab ({@link PaneHeaderTab}) and its content
+ * (the page wrapped in {@link AppShell}) in separate React trees/portals, so a
+ * normal React context provided inside the content cannot reach the tab. This
+ * global store bridges that gap: an AppShell-wrapped page registers its header
+ * `actions` node under its `paneId`, and the matching {@link PaneHeaderTab}
+ * reads it back to render those actions inside the pane header.
+ *
+ * Values are React nodes (a rendered element). The selector hook does a single
+ * `paneId` lookup and returns the stored node reference directly — no array or
+ * object derivation — so it stays referentially stable across unrelated store
+ * writes and never needs `useShallow`.
+ */
+interface PaneActionsState {
+  /** Maps a pane id to the header actions node that pane's page registered. */
+  actions: Record<string, ReactNode>;
+}
+
+const usePaneActionsStore = create<PaneActionsState>(() => ({
+  actions: {},
+}));
+
+/**
+ * Register (or replace) the header actions node for a pane. Skips the write
+ * when the node reference is unchanged so registering the same actions does not
+ * churn the store (and thus the subscribed tab).
+ */
+export function setPaneActions(paneId: string, node: ReactNode): void {
+  const current = usePaneActionsStore.getState().actions;
+  if (current[paneId] === node) {
+    return;
+  }
+  usePaneActionsStore.setState({ actions: { ...current, [paneId]: node } });
+}
+
+/** Remove a pane's registered actions (call on unmount). No-op if absent. */
+export function clearPaneActions(paneId: string): void {
+  const current = usePaneActionsStore.getState().actions;
+  if (!(paneId in current)) {
+    return;
+  }
+  const next = { ...current };
+  delete next[paneId];
+  usePaneActionsStore.setState({ actions: next });
+}
+
+/**
+ * Hook: the actions node registered for `paneId`, or undefined when none. A
+ * single map lookup keeps the selector stable — it returns the same node
+ * reference until that pane's actions are re-registered.
+ */
+export function usePaneActions(paneId: string): ReactNode {
+  return usePaneActionsStore((state) => state.actions[paneId]);
+}

--- a/apps/frontend/sentinel/src/store/workspace-store.ts
+++ b/apps/frontend/sentinel/src/store/workspace-store.ts
@@ -24,8 +24,15 @@ import {
  *      once across all panes" rule.
  *   3. Exposes imperative actions that drive the live `DockviewApi` once bound.
  *
+ * One-view-per-pane model:
+ *   - Every dockview group holds exactly one panel. Panels are never stacked
+ *     into a tab group (`Workspace.tsx` blocks center / tab-strip drops, the
+ *     split control creates new groups, and `openTab` swaps a pane's content
+ *     rather than adding panels).
+ *
  * Vocabulary:
- *   - "pane" == a dockview panel. `paneId` is the dockview panel id.
+ *   - "pane" == a dockview panel (and its sole-occupant group). `paneId` is the
+ *     dockview panel id.
  *   - Every panel carries `params.tabId` so a deserialized layout is
  *     self-describing and `openTabs` can be rebuilt on reload.
  */
@@ -65,9 +72,13 @@ export interface WorkspaceState {
   syncFromApi: () => void;
 
   /**
-   * Open a tab. If it is already open anywhere, focus that pane instead of
-   * creating a duplicate (at-most-once). Otherwise add a new pane.
-   * Returns the pane id hosting the tab, or null if no api is bound.
+   * Open a tab from the nav launcher. Behaviour (one-view-per-pane):
+   *   - Already open anywhere -> focus/activate that pane (no duplicate, no
+   *     move; preserves at-most-once).
+   *   - No panes yet -> create the first pane hosting the tab.
+   *   - Otherwise -> replace the *active* pane's content with this tab in place
+   *     (swap params, never add/stack a panel).
+   * Returns the pane id now hosting the tab, or null if no api is bound.
    */
   openTab: (tabId: WorkspaceTabId) => string | null;
   /**
@@ -78,9 +89,10 @@ export interface WorkspaceState {
   /** Close (remove) a pane. */
   closePane: (paneId: string) => void;
   /**
-   * Split `paneId` in `direction`, placing `tabId` in the new pane. Rejected
-   * (returns null) if `tabId` is already open elsewhere. Returns the new pane
-   * id, or null on rejection / no bound api.
+   * Split `paneId` in `direction`, placing `tabId` in a brand-new pane (its own
+   * group — never stacked into a tab group). Rejected (returns null) if `tabId`
+   * is already open elsewhere. Returns the new pane id, or null on rejection /
+   * no bound api.
    */
   splitPane: (
     paneId: string,
@@ -119,15 +131,34 @@ function computeOpenTabs(api: DockviewApi): Partial<Record<WorkspaceTabId, strin
   return next;
 }
 
-/** Map our SplitDirection onto dockview's positional AddPanelOptions. */
+/**
+ * Map our SplitDirection onto dockview's positional AddPanelOptions. A
+ * directional add (left/right/above/below) relative to a panel always lands the
+ * new panel in its own new group. `'within'` is the only stacking direction, so
+ * we coerce it to `'right'` to keep the one-view-per-pane invariant.
+ */
 function toAddPanelPosition(
   referencePanel: string,
   direction: SplitDirection,
 ): AddPanelOptions['position'] {
+  const positional: Direction = direction === 'within' ? 'right' : (direction as Direction);
   return {
     referencePanel,
-    direction: direction as Direction,
+    direction: positional,
   };
+}
+
+/**
+ * Resolve the pane the launcher should replace: the active panel, else the
+ * active group's active panel, else the last panel. `undefined` when empty.
+ */
+function resolveActivePane(api: DockviewApi): string | undefined {
+  const active = api.activePanel;
+  if (active) return active.id;
+  const groupActive = api.activeGroup?.activePanel;
+  if (groupActive) return groupActive.id;
+  const panels = api.panels;
+  return panels.length > 0 ? panels[panels.length - 1].id : undefined;
 }
 
 export const useWorkspaceStore = create<WorkspaceState>()(
@@ -164,6 +195,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
       openTab: (tabId) => {
         if (!liveApi) return null;
+
+        // Already open somewhere: jump to it. Never duplicate or move.
         const existingPaneId = get().openTabs[tabId];
         if (existingPaneId) {
           const panel = liveApi.getPanel(existingPaneId);
@@ -172,15 +205,29 @@ export const useWorkspaceStore = create<WorkspaceState>()(
             return existingPaneId;
           }
         }
-        const paneId = makePaneId(tabId);
+
         const params: WorkspacePaneParams = { tabId };
-        liveApi.addPanel({
-          id: paneId,
-          component: WORKSPACE_PANEL_COMPONENT,
-          params,
-        });
+
+        // Empty workspace: create the first pane (its own group).
+        const activePaneId = resolveActivePane(liveApi);
+        if (!activePaneId) {
+          const paneId = makePaneId(tabId);
+          liveApi.addPanel({
+            id: paneId,
+            component: WORKSPACE_PANEL_COMPONENT,
+            params,
+          });
+          get().syncFromApi();
+          return paneId;
+        }
+
+        // Replace the active pane's content in place: swap params, no new panel.
+        const activePane = liveApi.getPanel(activePaneId);
+        if (!activePane) return null;
+        activePane.api.updateParameters(params);
+        activePane.api.setActive();
         get().syncFromApi();
-        return paneId;
+        return activePaneId;
       },
 
       setPaneTab: (paneId, tabId) => {
@@ -235,6 +282,13 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     {
       name: STORAGE_KEY,
       storage: createJSONStorage(() => localStorage),
+      // v2 introduced one-view-per-pane; drop any pre-v2 layout (it may contain
+      // stacked tab groups) so it doesn't render stacked after the upgrade.
+      version: 2,
+      migrate: (persisted, fromVersion) => {
+        if (fromVersion < 2) return { layout: null, openTabs: {} };
+        return persisted as { layout: SerializedDockview | null; openTabs: Partial<Record<WorkspaceTabId, string>> };
+      },
       // Only persist the serializable layout + open-tab map; actions and the
       // live api are runtime-only.
       partialize: (state) => ({

--- a/apps/frontend/sentinel/src/store/workspace-store.ts
+++ b/apps/frontend/sentinel/src/store/workspace-store.ts
@@ -1,0 +1,278 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { useShallow } from 'zustand/react/shallow';
+import type {
+  DockviewApi,
+  SerializedDockview,
+  AddPanelOptions,
+  Direction,
+} from 'dockview-react';
+
+import {
+  WORKSPACE_TAB_IDS,
+  isWorkspaceTabId,
+  type WorkspaceTabId,
+} from '../lib/workspace-tabs';
+
+/**
+ * Workspace store
+ * ---------------
+ * dockview owns the live tiling UI (split / resize / drag / close). This store:
+ *   1. Persists the serialized dockview layout to localStorage so it survives
+ *      reloads.
+ *   2. Tracks which tab each pane shows and enforces the "each tab open at most
+ *      once across all panes" rule.
+ *   3. Exposes imperative actions that drive the live `DockviewApi` once bound.
+ *
+ * Vocabulary:
+ *   - "pane" == a dockview panel. `paneId` is the dockview panel id.
+ *   - Every panel carries `params.tabId` so a deserialized layout is
+ *     self-describing and `openTabs` can be rebuilt on reload.
+ */
+
+/** The single content component id registered with DockviewReact. */
+export const WORKSPACE_PANEL_COMPONENT = 'workspace-pane';
+
+/** localStorage key for the persisted layout. */
+const STORAGE_KEY = 'sentinel.workspace';
+
+/** Direction a split can target. Mirrors dockview's positional Direction. */
+export type SplitDirection = 'left' | 'right' | 'above' | 'below' | 'within';
+
+/** Params attached to every dockview panel created by the workspace. */
+export interface WorkspacePaneParams {
+  tabId: WorkspaceTabId;
+}
+
+export interface WorkspaceState {
+  /**
+   * Serialized dockview layout, persisted across reloads. `null` before the
+   * first layout is created. Compatible with `DockviewApi.toJSON()/fromJSON()`.
+   */
+  layout: SerializedDockview | null;
+  /**
+   * Maps an open tab id to the pane (dockview panel) id that hosts it.
+   * Source of truth for the at-most-once rule and duplicate-disable selectors.
+   * Persisted so reloads can be reconciled against the restored layout.
+   */
+  openTabs: Partial<Record<WorkspaceTabId, string>>;
+
+  // --- actions ---------------------------------------------------------------
+
+  /** Register the live DockviewApi. Returns a disposer to call on unmount. */
+  bindApi: (api: DockviewApi | null) => () => void;
+  /** Pull the current serialized layout + open-tab map out of the live api. */
+  syncFromApi: () => void;
+
+  /**
+   * Open a tab. If it is already open anywhere, focus that pane instead of
+   * creating a duplicate (at-most-once). Otherwise add a new pane.
+   * Returns the pane id hosting the tab, or null if no api is bound.
+   */
+  openTab: (tabId: WorkspaceTabId) => string | null;
+  /**
+   * Switch an existing pane to show `tabId`. Rejected (returns false) when that
+   * tab is already open in a different pane.
+   */
+  setPaneTab: (paneId: string, tabId: WorkspaceTabId) => boolean;
+  /** Close (remove) a pane. */
+  closePane: (paneId: string) => void;
+  /**
+   * Split `paneId` in `direction`, placing `tabId` in the new pane. Rejected
+   * (returns null) if `tabId` is already open elsewhere. Returns the new pane
+   * id, or null on rejection / no bound api.
+   */
+  splitPane: (
+    paneId: string,
+    tabId: WorkspaceTabId,
+    direction: SplitDirection,
+  ) => string | null;
+  /** Remove every pane and clear the layout. */
+  resetWorkspace: () => void;
+}
+
+let liveApi: DockviewApi | null = null;
+
+/** Build a stable, unique pane id for a freshly opened tab. */
+function makePaneId(tabId: WorkspaceTabId): string {
+  return `pane-${tabId}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Read `params.tabId` off a dockview panel, validated against the registry. */
+function readPanelTabId(panel: { params?: Record<string, unknown> }): WorkspaceTabId | null {
+  const raw = panel.params?.tabId;
+  if (typeof raw === 'string' && isWorkspaceTabId(raw)) {
+    return raw;
+  }
+  return null;
+}
+
+/** Rebuild the open-tab map from the panels currently held by the live api. */
+function computeOpenTabs(api: DockviewApi): Partial<Record<WorkspaceTabId, string>> {
+  const next: Partial<Record<WorkspaceTabId, string>> = {};
+  for (const panel of api.panels) {
+    const tabId = readPanelTabId(panel);
+    if (tabId && !next[tabId]) {
+      next[tabId] = panel.id;
+    }
+  }
+  return next;
+}
+
+/** Map our SplitDirection onto dockview's positional AddPanelOptions. */
+function toAddPanelPosition(
+  referencePanel: string,
+  direction: SplitDirection,
+): AddPanelOptions['position'] {
+  return {
+    referencePanel,
+    direction: direction as Direction,
+  };
+}
+
+export const useWorkspaceStore = create<WorkspaceState>()(
+  persist(
+    (set, get) => ({
+      layout: null,
+      openTabs: {},
+
+      bindApi: (api) => {
+        liveApi = api;
+        if (!api) {
+          return () => {};
+        }
+        const disposable = api.onDidLayoutChange(() => {
+          get().syncFromApi();
+        });
+        // Capture initial state immediately after binding.
+        get().syncFromApi();
+        return () => {
+          disposable.dispose();
+          if (liveApi === api) {
+            liveApi = null;
+          }
+        };
+      },
+
+      syncFromApi: () => {
+        if (!liveApi) return;
+        set({
+          layout: liveApi.toJSON(),
+          openTabs: computeOpenTabs(liveApi),
+        });
+      },
+
+      openTab: (tabId) => {
+        if (!liveApi) return null;
+        const existingPaneId = get().openTabs[tabId];
+        if (existingPaneId) {
+          const panel = liveApi.getPanel(existingPaneId);
+          if (panel) {
+            panel.api.setActive();
+            return existingPaneId;
+          }
+        }
+        const paneId = makePaneId(tabId);
+        const params: WorkspacePaneParams = { tabId };
+        liveApi.addPanel({
+          id: paneId,
+          component: WORKSPACE_PANEL_COMPONENT,
+          params,
+        });
+        get().syncFromApi();
+        return paneId;
+      },
+
+      setPaneTab: (paneId, tabId) => {
+        if (!liveApi) return false;
+        const owner = get().openTabs[tabId];
+        if (owner && owner !== paneId) {
+          return false;
+        }
+        const panel = liveApi.getPanel(paneId);
+        if (!panel) return false;
+        const params: WorkspacePaneParams = { tabId };
+        panel.api.updateParameters(params);
+        get().syncFromApi();
+        return true;
+      },
+
+      closePane: (paneId) => {
+        if (!liveApi) return;
+        const panel = liveApi.getPanel(paneId);
+        if (!panel) return;
+        liveApi.removePanel(panel);
+        get().syncFromApi();
+      },
+
+      splitPane: (paneId, tabId, direction) => {
+        if (!liveApi) return null;
+        const owner = get().openTabs[tabId];
+        if (owner) {
+          return null;
+        }
+        const reference = liveApi.getPanel(paneId);
+        if (!reference) return null;
+        const newPaneId = makePaneId(tabId);
+        const params: WorkspacePaneParams = { tabId };
+        liveApi.addPanel({
+          id: newPaneId,
+          component: WORKSPACE_PANEL_COMPONENT,
+          params,
+          position: toAddPanelPosition(paneId, direction),
+        });
+        get().syncFromApi();
+        return newPaneId;
+      },
+
+      resetWorkspace: () => {
+        if (liveApi) {
+          liveApi.clear();
+        }
+        set({ layout: null, openTabs: {} });
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      // Only persist the serializable layout + open-tab map; actions and the
+      // live api are runtime-only.
+      partialize: (state) => ({
+        layout: state.layout,
+        openTabs: state.openTabs,
+      }),
+    },
+  ),
+);
+
+// --- selectors ---------------------------------------------------------------
+
+/**
+ * Hook: returns the set of tab ids currently open in any pane. Pickers use this
+ * to disable tabs that would violate the at-most-once rule.
+ */
+export function useOpenTabIds(): WorkspaceTabId[] {
+  return useWorkspaceStore(
+    useShallow((state) => WORKSPACE_TAB_IDS.filter((id) => Boolean(state.openTabs[id]))),
+  );
+}
+
+/** Hook: is a specific tab currently open in any pane. */
+export function useIsTabOpen(tabId: WorkspaceTabId): boolean {
+  return useWorkspaceStore((state) => Boolean(state.openTabs[tabId]));
+}
+
+/** Hook: the pane id hosting `tabId`, or undefined when closed. */
+export function usePaneIdForTab(tabId: WorkspaceTabId): string | undefined {
+  return useWorkspaceStore((state) => state.openTabs[tabId]);
+}
+
+/** Hook: the persisted serialized layout (null before first use). */
+export function useWorkspaceLayout(): SerializedDockview | null {
+  return useWorkspaceStore((state) => state.layout);
+}
+
+/** Non-reactive read of the full open-tab map (for imperative call sites). */
+export function getOpenTabsSnapshot(): Partial<Record<WorkspaceTabId, string>> {
+  return useWorkspaceStore.getState().openTabs;
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,7 +44,7 @@ services:
   sentinel-frontend:
     image: node:22-alpine
     working_dir: /app
-    command: sh -c "if [ ! -x node_modules/.bin/vite ]; then npm ci; fi && npm run dev -- --host --port 5173"
+    command: sh -c "npm install --no-audit --no-fund && npm run dev -- --host --port 5173"
     environment:
       VITE_BASE_PATH: /
       VITE_ROUTER_BASENAME: /


### PR DESCRIPTION
## Summary
Replaces the single-tab view with a **dockview-based tiling workspace** and consolidates each page's chrome into the pane header, removing the old double-header.

## What's included
- **Tiling workspace (dockview)** — split/resize/drag panes; one view per pane (stacking drops blocked); layout persisted in the workspace store with a safe reset on corrupt/incompatible state.
- **Standalone workspace tabs** — Desktop, Terminal, and Files are first-class tabs alongside Sessions.
- **One-view-per-pane + empty-state UX** — clicking a sidebar item switches the active pane; an empty workspace shows a themed "Open a tab" overlay (fixed the grey/click-through issues).
- **Pane-header action merge** — each page's actions render inside its pane header via a paneId-keyed store (no second header bar); global controls (instance switcher, home) moved to the sidebar.
- **Unified header-action pills** — Sessions' Max-steps control is now a portaled dropdown matching Effort/Agent-mode; all control pills are compact `h-7`. Logs / Memory / Triggers / Git / Admin / TriggerDetail restyled to the same language: bordered pills, circular icon-pills for refresh/delete, no dividers.
- **Dev container** installs missing deps on start so the stack self-heals after a stale node_modules volume.

## Notes
- 6 commits, 33 files.
- Frontend build (`tsc -b && vite build`) is green.
- Needs a manual smoke pass: split/drag panes, sidebar→pane switching, the restyled dropdowns/pills, and layout persistence across reload.